### PR TITLE
[BE] Add MediaPipe face landmark extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ postgres_data/
 # IDE
 .vscode/
 .idea/
+
+models

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    libgl1 \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/backend/pipeline/face.py
+++ b/backend/pipeline/face.py
@@ -1,0 +1,66 @@
+import mediapipe as mp
+from mediapipe.tasks import python
+from mediapipe.tasks.python import vision
+import numpy as np
+
+MODEL_PATH = "models/face_landmarker.task"
+
+# 랜드마크 인덱스 (MediaPipe 468개 중 주요 부위)
+ROI_INDICES = {
+    "forehead": [10, 67, 69, 104, 108, 151, 299, 337, 338],
+    "left_cheek": [116, 117, 118, 119, 120, 121, 126, 142, 203],
+    "right_cheek": [345, 346, 347, 348, 349, 350, 355, 371, 423],
+    "nose": [1, 2, 3, 4, 5, 6, 168, 197, 195],
+    "chin": [152, 175, 176, 177, 178, 194, 199, 200, 201],
+}
+
+def load_landmarker():
+    base_options = python.BaseOptions(model_asset_path=MODEL_PATH)
+    options = vision.FaceLandmarkerOptions(
+        base_options=base_options,
+        num_faces=1,
+    )
+    return vision.FaceLandmarker.create_from_options(options)
+
+def extract_landmarks(image_path: str) -> dict:
+    landmarker = load_landmarker()
+
+    # 이미지 로드
+    mp_image = mp.Image.create_from_file(image_path)
+    result = landmarker.detect(mp_image)
+
+    # 얼굴 미감지 처리
+    if not result.face_landmarks:
+        raise ValueError("얼굴을 감지할 수 없습니다.")
+
+    landmarks = result.face_landmarks[0]
+    h, w = mp_image.height, mp_image.width
+
+    # 픽셀 좌표로 변환
+    points = [
+        (int(lm.x * w), int(lm.y * h))
+        for lm in landmarks
+    ]
+
+    # 바운딩박스 추출
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    bbox = {
+        "x_min": min(xs),
+        "x_max": max(xs),
+        "y_min": min(ys),
+        "y_max": max(ys),
+    }
+
+    # ROI 좌표 추출
+    roi_points = {
+        region: [points[i] for i in indices]
+        for region, indices in ROI_INDICES.items()
+    }
+
+    return {
+        "landmarks": points,
+        "bbox": bbox,
+        "roi_points": roi_points,
+        "image_size": {"width": w, "height": h},
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,5 @@ mediapipe
 opencv-python-headless
 pydantic-settings==2.2.1
 sqlalchemy
+
+

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -1,5 +1,6 @@
 import uuid, os, tempfile
 from fastapi import APIRouter, UploadFile, File, HTTPException
+from pipeline.face import extract_landmarks
 router = APIRouter()
 
 ALLOWED_TYPES = ["image/jpeg", "image/png", "image/heic", "image/webp"]
@@ -35,5 +36,22 @@ async def analyze_skin(file: UploadFile = File(...)):
         }
     finally:
         # 임시파일 삭제
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+@router.post("/test-landmarks")
+async def test_landmarks(file: UploadFile = File(...)):
+    contents = await file.read()
+    
+    tmp_path = f"/tmp/{uuid.uuid4()}.jpg"
+    with open(tmp_path, "wb") as f:
+        f.write(contents)
+    
+    try:
+        result = extract_landmarks(tmp_path)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)


### PR DESCRIPTION
## Summary
Implement MediaPipe Face Landmarker pipeline for facial landmark extraction.

## Changes
- Add `pipeline/face.py` — Face Landmarker model load and landmark extraction
- Add `models/face_landmarker.task` — MediaPipe face landmarker model
- Add ROI region indices (forehead, cheeks, nose, chin)
- Add bounding box extraction from landmark coordinates
- Add face not detected error handling
- Fix Dockerfile — add libgl1, libglib2.0-0 for OpenCV compatibility

## Checklist
- [x] MediaPipe Face Landmarker model loaded
- [x] 468 facial landmarks extracted
- [x] Face not detected error handling
- [x] Bounding box extraction
- [x] ROI region separation (forehead, left_cheek, right_cheek, nose, chin)

Closes #11