### PR TITLE
[BE] Add OpenCV preprocessing pipeline

### DIFF
--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -1,0 +1,43 @@
+import cv2
+import numpy as np
+
+def preprocess_roi(image_path: str, roi_points: dict) -> dict:
+    # 1. 이미지 로드
+    image = cv2.imread(image_path)
+    
+    result = {}
+    
+    for region, points in roi_points.items():
+        # 2. 마스크 생성 (검정 배경)
+        mask = np.zeros(image.shape[:2], dtype=np.uint8)
+        
+        # 3. ROI 영역 흰색으로 채우기
+        pts = np.array(points, dtype=np.int32)
+        cv2.fillPoly(mask, [pts], 255)
+        
+        # 4. 마스크 적용 → 해당 부위만 남김
+        roi = cv2.bitwise_and(image, image, mask=mask)
+        
+        # 5. BGR → LAB 변환
+        lab = cv2.cvtColor(roi, cv2.COLOR_BGR2LAB)
+        
+        # 6. BGR → HSV 변환
+        hsv = cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
+        
+        # 7. CLAHE 조명 보정 (LAB의 L채널에 적용)
+        clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+        l, a, b = cv2.split(lab)
+        l_corrected = clahe.apply(l)
+        lab_corrected = cv2.merge([l_corrected, a, b])
+        
+        # 8. 노이즈 제거
+        denoised = cv2.GaussianBlur(lab_corrected, (5, 5), 0)
+        
+        result[region] = {
+            "lab": lab_corrected,
+            "hsv": hsv,
+            "denoised": denoised,
+            "mask": mask,
+        }
+    
+    return result

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -1,6 +1,8 @@
 import uuid, os, tempfile
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from pipeline.face import extract_landmarks
+from pipeline.preprocess import preprocess_roi
+
 router = APIRouter()
 
 ALLOWED_TYPES = ["image/jpeg", "image/png", "image/heic", "image/webp"]
@@ -50,6 +52,31 @@ async def test_landmarks(file: UploadFile = File(...)):
     try:
         result = extract_landmarks(tmp_path)
         return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+
+@router.post("/test-preprocess")
+async def test_preprocess(file: UploadFile = File(...)):
+    contents = await file.read()
+    
+    tmp_path = f"/tmp/{uuid.uuid4()}.jpg"
+    with open(tmp_path, "wb") as f:
+        f.write(contents)
+    
+    try:
+        from pipeline.face import extract_landmarks
+        landmarks = extract_landmarks(tmp_path)
+        roi_result = preprocess_roi(tmp_path, landmarks["roi_points"])
+        
+        return {
+            "regions": list(roi_result.keys()),
+            "message": "preprocess ok"
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:


### PR DESCRIPTION
## Summary
Implement OpenCV-based ROI masking and image preprocessing pipeline.

## Changes
- Add `pipeline/preprocess.py` — ROI masking and preprocessing per facial region
- ROI masking using landmark coordinates (forehead, cheeks, nose, chin)
- BGR → LAB, HSV color space conversion
- CLAHE lighting correction on LAB L-channel
- Gaussian blur noise reduction

## Checklist
- [x] OpenCV image load
- [x] Landmark-based ROI masking
- [x] BGR → LAB, HSV conversion
- [x] CLAHE lighting correction
- [x] Gaussian blur noise reduction

Closes #12