### PR TITLE
[BE] Add skin condition scoring logic

### DIFF
--- a/backend/pipeline/scoring.py
+++ b/backend/pipeline/scoring.py
@@ -1,0 +1,118 @@
+import cv2
+import numpy as np
+
+def calculate_scores(preprocessed: dict) -> dict:
+    redness_scores = []
+    brightness_scores = []
+    tone_scores = []
+    trouble_scores = []
+
+    for region, data in preprocessed.items():
+        lab = data["lab"]
+        mask = data["mask"]
+
+        # 마스크 적용된 픽셀만 추출
+        masked_pixels = lab[mask == 255]
+        if len(masked_pixels) == 0:
+            continue
+
+        l_channel = masked_pixels[:, 0].astype(float)
+        a_channel = masked_pixels[:, 1].astype(float)
+
+        # 붉은기 — a채널 평균 (128 기준, 높을수록 붉음)
+        redness = float(np.mean(a_channel))
+        redness_scores.append(redness)
+
+        # 밝기 — L채널 평균
+        brightness = float(np.mean(l_channel))
+        brightness_scores.append(brightness)
+
+        # 톤 불균형 — L채널 분산
+        tone_var = float(np.var(l_channel))
+        tone_scores.append(tone_var)
+
+        # 트러블 — a채널에서 이상 픽셀 비율
+        trouble_pixels = np.sum(a_channel > 140)
+        trouble_ratio = float(trouble_pixels / len(masked_pixels))
+        trouble_scores.append(trouble_ratio)
+
+    # 평균값 계산
+    avg_redness = np.mean(redness_scores) if redness_scores else 128
+    avg_brightness = np.mean(brightness_scores) if brightness_scores else 128
+    avg_tone = np.mean(tone_scores) if tone_scores else 0
+    avg_trouble = np.mean(trouble_scores) if trouble_scores else 0
+
+    # 0~100 정규화
+    redness_score = float(np.clip((avg_redness - 128) / 20 * 100, 0, 100))
+    brightness_score = float(np.clip(avg_brightness / 255 * 100, 0, 100))
+    tone_score = float(np.clip(100 - (avg_tone / 500 * 100), 0, 100))
+    trouble_score = float(np.clip(avg_trouble * 100 * 3, 0, 100))
+    moisture_score = float(np.clip((brightness_score + (100 - redness_score)) / 2, 0, 100))
+
+    # 차트용 점수 (높을수록 좋음으로 정규화)
+    def get_status(score, reverse=False):
+        s = 100 - score if reverse else score
+        if s >= 60:
+            return "good"
+        elif s >= 40:
+            return "caution"
+        else:
+            return "bad"
+
+    def get_label(metric, status):
+        labels = {
+            "redness":    {"good": "진정됨", "caution": "약간 붉음", "bad": "붉음"},
+            "tone":       {"good": "균일", "caution": "약간 불균일", "bad": "불균일"},
+            "brightness": {"good": "밝음", "caution": "보통", "bad": "칙칙함"},
+            "trouble":    {"good": "깨끗", "caution": "약간 있음", "bad": "트러블"},
+            "moisture":   {"good": "촉촉", "caution": "보통", "bad": "건조"},
+        }
+        return labels[metric][status]
+
+    redness_status = get_status(redness_score, reverse=True)
+    tone_status = get_status(tone_score)
+    brightness_status = get_status(brightness_score)
+    trouble_status = get_status(trouble_score, reverse=True)
+    moisture_status = get_status(moisture_score)
+
+    overall = float(np.mean([
+        100 - redness_score,
+        tone_score,
+        brightness_score,
+        100 - trouble_score,
+        moisture_score,
+    ]))
+
+    return {
+        "redness": {
+            "score": round(redness_score, 1),
+            "chart_score": round(100 - redness_score, 1),
+            "status": redness_status,
+            "label": get_label("redness", redness_status),
+        },
+        "tone": {
+            "score": round(tone_score, 1),
+            "chart_score": round(tone_score, 1),
+            "status": tone_status,
+            "label": get_label("tone", tone_status),
+        },
+        "brightness": {
+            "score": round(brightness_score, 1),
+            "chart_score": round(brightness_score, 1),
+            "status": brightness_status,
+            "label": get_label("brightness", brightness_status),
+        },
+        "trouble": {
+            "score": round(trouble_score, 1),
+            "chart_score": round(100 - trouble_score, 1),
+            "status": trouble_status,
+            "label": get_label("trouble", trouble_status),
+        },
+        "moisture": {
+            "score": round(moisture_score, 1),
+            "chart_score": round(moisture_score, 1),
+            "status": moisture_status,
+            "label": get_label("moisture", moisture_status),
+        },
+        "overall": round(overall, 1),
+    }

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -82,3 +82,23 @@ async def test_preprocess(file: UploadFile = File(...)):
     finally:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
+
+
+from pipeline.scoring import calculate_scores
+
+@router.post("/test-scores")
+async def test_scores(file: UploadFile = File(...)):
+    contents = await file.read()
+    tmp_path = f"/tmp/{uuid.uuid4()}.jpg"
+    with open(tmp_path, "wb") as f:
+        f.write(contents)
+    try:
+        landmarks = extract_landmarks(tmp_path)
+        preprocessed = preprocess_roi(tmp_path, landmarks["roi_points"])
+        scores = calculate_scores(preprocessed)
+        return scores
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)


### PR DESCRIPTION
## Summary
Implement skin condition scoring logic based on LAB color space analysis.

## Changes
- Add `pipeline/scoring.py` — skin condition score calculation per region
- Redness score — LAB a-channel mean value
- Tone score — LAB L-channel variance
- Brightness score — LAB L-channel mean value
- Trouble score — abnormal pixel ratio in a-channel
- Moisture score — derived from brightness and redness
- Normalize all scores to 0~100
- Add status classification (good / caution / bad)
- Add Korean labels per metric
- Add chart_score normalization (higher = better)
- Add overall score calculation

## Checklist
- [x] Redness score
- [x] Tone unevenness score
- [x] Brightness score
- [x] Trouble area score
- [x] Moisture score
- [x] 0~100 normalization
- [x] Overall score

Closes #13