### PR TITLE
feat: Google OAuth login and session handling

### DIFF
--- a/backend/alembic/versions/002_add_users_and_history.py
+++ b/backend/alembic/versions/002_add_users_and_history.py
@@ -1,0 +1,44 @@
+"""add users and analysis history tables
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("""
+        CREATE TABLE IF NOT EXISTS users (
+            id              VARCHAR PRIMARY KEY,
+            google_id       VARCHAR NOT NULL UNIQUE,
+            email           VARCHAR NOT NULL UNIQUE,
+            name            VARCHAR,
+            profile_image   VARCHAR,
+            created_at      TIMESTAMP DEFAULT NOW()
+        )
+    """))
+
+    op.execute(sa.text("""
+        CREATE TABLE IF NOT EXISTS analysis_history (
+            id          VARCHAR PRIMARY KEY,
+            user_id     VARCHAR NOT NULL REFERENCES users(id),
+            skin_scores JSON,
+            skin_type   VARCHAR,
+            analyzed_at TIMESTAMP DEFAULT NOW()
+        )
+    """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP TABLE IF EXISTS analysis_history"))
+    op.execute(sa.text("DROP TABLE IF EXISTS users"))

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from fastapi import Cookie
+
+from core.config import settings
+
+ALGORITHM = "HS256"
+TOKEN_EXPIRE_DAYS = 7
+
+
+def create_access_token(data: dict) -> str:
+    to_encode = data.copy()
+    to_encode["exp"] = datetime.utcnow() + timedelta(days=TOKEN_EXPIRE_DAYS)
+    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=ALGORITHM)
+
+
+def decode_token(token: str) -> dict:
+    return jwt.decode(token, settings.jwt_secret_key, algorithms=[ALGORITHM])
+
+
+def get_current_user(access_token: str = Cookie(default=None)):
+    """Optional auth dependency — returns user dict or None."""
+    if not access_token:
+        return None
+    try:
+        payload = decode_token(access_token)
+        return {
+            "id": payload["sub"],
+            "email": payload["email"],
+            "name": payload["name"],
+            "picture": payload.get("picture"),
+        }
+    except JWTError:
+        return None

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -6,11 +6,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 class Settings(BaseSettings):
     database_url: str
-    anthropic_api_key: str = "" 
+    anthropic_api_key: str = ""
     gemini_api_key: str = ""
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""
     aws_bucket_name: str = ""
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    jwt_secret_key: str = "dev-secret-change-in-production"
 
     class Config:
         env_file = str(BASE_DIR / ".env")

--- a/backend/data/seed.py
+++ b/backend/data/seed.py
@@ -133,7 +133,7 @@ def seed_skin_types(db):
             db.add(SkinProfile(id=str(uuid.uuid4()), **profile_data))
 
     db.commit()
-    print(f"{len(SKIN_TYPES)}개 피부 타입, {len(SKIN_PROFILES)}개 프로필 저장 완료!")
+    print(f"{len(SKIN_TYPES)}개 피부 타입, {len(SKIN_PROFILES)}개 profile 저장 완료!")
 
 
 def seed():

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,9 +1,10 @@
 import enum
 import uuid
 
-from sqlalchemy import Column, String, Float, Integer, JSON, Text, ForeignKey, Enum as SAEnum
+from sqlalchemy import Column, String, Float, Integer, JSON, Text, ForeignKey, Enum as SAEnum, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from datetime import datetime
 
 Base = declarative_base()
 
@@ -60,6 +61,31 @@ class SkinProfile(Base):
     tone_max = Column(Float)
 
     skin_type = relationship("SkinType", back_populates="profiles")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    google_id = Column(String, unique=True, nullable=False)
+    email = Column(String, unique=True, nullable=False)
+    name = Column(String)
+    profile_image = Column(String)
+    created_at = Column(DateTime, default=datetime.now)
+
+    analysis_history = relationship("AnalysisHistory", back_populates="user")
+
+
+class AnalysisHistory(Base):
+    __tablename__ = "analysis_history"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    skin_scores = Column(JSON)
+    skin_type = Column(String)
+    analyzed_at = Column(DateTime, default=datetime.now)
+
+    user = relationship("User", back_populates="analysis_history")
 
 
 class Product(Base):

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import analyze, recommend
+from routers import analyze, recommend, auth
 
 app = FastAPI(title='face')
 
@@ -14,6 +14,8 @@ app.add_middleware(
 
 app.include_router(analyze.router, prefix='/analyze', tags=['analyze'])
 app.include_router(recommend.router, prefix='/recommend', tags=['recommend'])
+app.include_router(auth.router, prefix='/auth', tags=['auth'])
+
 
 @app.get('/health')
 def health():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,5 +10,7 @@ opencv-python-headless
 pydantic-settings==2.2.1
 sqlalchemy
 alembic
+python-jose[cryptography]
+httpx
 google-generativeai
 

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -1,13 +1,13 @@
 import uuid, os
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
-from numpy import number
 from sqlalchemy.orm import Session
 from db.session import get_db
-from db.models import Product
+from db.models import Product, AnalysisHistory
 from pipeline.face import extract_landmarks
 from pipeline.preprocess import preprocess_roi
 from pipeline.scoring import calculate_scores
 from pipeline.gemini import generate_recommendation_reason
+from core.auth import get_current_user
 from datetime import datetime
 
 router = APIRouter()
@@ -20,7 +20,11 @@ def analyze_health():
     return {"message": "analyze router ok"}
 
 @router.post("/")
-async def analyze_skin(file: UploadFile = File(...), db: Session = Depends(get_db)):
+async def analyze_skin(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
 
     if file.content_type not in ALLOWED_TYPES:
         raise HTTPException(status_code=400, detail="지원하지 않는 파일 형식입니다.")
@@ -99,13 +103,23 @@ async def analyze_skin(file: UploadFile = File(...), db: Session = Depends(get_d
         for p in top_products:
             p["reason"] = reason
 
+        if current_user:
+            db.add(AnalysisHistory(
+                id=str(uuid.uuid4()),
+                user_id=current_user["id"],
+                skin_scores=scores,
+                skin_type=skin_type,
+                analyzed_at=datetime.now(),
+            ))
+            db.commit()
+
         return {
             "skin_scores": scores,
             "skin_type": skin_type,
             "products": top_products,
             "analyzed_at": datetime.now().isoformat(),
             "landmarks": landmarks["landmarks"],
-            "image_size": landmarks["image_size"],  
+            "image_size": landmarks["image_size"],
         }
 
     except ValueError as e:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,92 @@
+import uuid
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, Cookie, Depends
+from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from core.auth import create_access_token, decode_token, get_current_user
+from core.config import settings
+from db.models import User
+from db.session import get_db
+
+router = APIRouter()
+
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+REDIRECT_URI = "http://localhost:8000/auth/google/callback"
+
+
+@router.get("/login")
+def login():
+    params = urlencode({
+        "client_id": settings.google_client_id,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": "openid email profile",
+        "access_type": "offline",
+    })
+    return RedirectResponse(f"{GOOGLE_AUTH_URL}?{params}")
+
+
+@router.get("/google/callback")
+async def callback(code: str, db: Session = Depends(get_db)):
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(GOOGLE_TOKEN_URL, data={
+            "client_id": settings.google_client_id,
+            "client_secret": settings.google_client_secret,
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": REDIRECT_URI,
+        })
+        access = token_resp.json()["access_token"]
+
+        userinfo_resp = await client.get(
+            GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        info = userinfo_resp.json()
+
+    user = db.query(User).filter(User.google_id == info["sub"]).first()
+    if not user:
+        user = User(
+            id=str(uuid.uuid4()),
+            google_id=info["sub"],
+            email=info["email"],
+            name=info.get("name", ""),
+            profile_image=info.get("picture", ""),
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    token = create_access_token({
+        "sub": user.id,
+        "email": user.email,
+        "name": user.name,
+        "picture": user.profile_image,
+    })
+
+    response = RedirectResponse(url="http://localhost:3000")
+    response.set_cookie(
+        key="access_token",
+        value=token,
+        httponly=True,
+        samesite="lax",
+        max_age=60 * 60 * 24 * 7,
+    )
+    return response
+
+
+@router.get("/me")
+def me(current_user=Depends(get_current_user)):
+    return {"user": current_user}
+
+
+@router.post("/logout")
+def logout():
+    response = JSONResponse({"ok": True})
+    response.delete_cookie("access_token")
+    return response

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { User, Mail, LogOut } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { BottomNav } from "@/components/bottom-nav"
+import { DesktopSidebar } from "@/components/desktop-sidebar"
+import { useAuth } from "@/hooks/useAuth"
+
+export default function ProfilePage() {
+  const { user, loading, logout } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`)
+    }
+  }, [user, loading, router])
+
+  if (loading || !user) return null
+
+  const handleLogout = async () => {
+    await logout()
+    router.replace("/")
+  }
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+
+      <div className="flex min-w-0 flex-1 flex-col pb-24">
+        <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur-sm">
+          <div className="px-4 py-4">
+            <h1 className="text-xl font-semibold text-foreground">profile</h1>
+          </div>
+        </header>
+
+        <main className="px-4 py-8 space-y-6">
+          {/* profile 카드 */}
+          <div className="flex flex-col items-center gap-4 rounded-2xl border border-border/50 bg-white p-8 shadow-sm">
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#FDF2F8]">
+              {user.picture ? (
+                <img
+                  src={user.picture}
+                  alt={user.name}
+                  className="h-20 w-20 rounded-full object-cover"
+                />
+              ) : (
+                <User className="h-10 w-10 text-[#F9A8C9]" />
+              )}
+            </div>
+            <div className="text-center">
+              <p className="text-lg font-semibold text-foreground">{user.name}</p>
+              <p className="flex items-center gap-1 text-sm text-muted-foreground">
+                <Mail className="h-3.5 w-3.5" />
+                {user.email}
+              </p>
+            </div>
+          </div>
+
+          {/* logout 버튼 */}
+          <Button
+            variant="outline"
+            className="w-full rounded-xl py-6 text-sm font-medium text-muted-foreground"
+            onClick={handleLogout}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            logout
+          </Button>
+        </main>
+      </div>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/frontend/src/components/bottom-nav.tsx
+++ b/frontend/src/components/bottom-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { Home, History, Camera, Sparkles, User } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
+import { useAuth } from "@/hooks/useAuth"
 
 interface NavItemProps {
   icon: React.ReactNode
@@ -38,12 +39,15 @@ function NavItem({ icon, label, href, badge }: NavItemProps) {
 }
 
 export function BottomNav() {
+  const { user } = useAuth()
+  const profileHref = user ? "/profile" : `${process.env.NEXT_PUBLIC_API_URL}/auth/login`
+
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border/50 bg-white/80 backdrop-blur-lg lg:hidden">
       <div className="mx-auto flex max-w-md items-center justify-around px-4 pb-6 pt-2">
         <NavItem icon={<Home className="h-5 w-5" />} label="Home" href="/" />
-        <NavItem icon={<History className="h-5 w-5" />} label="History" href="/history"/>
-        
+        <NavItem icon={<History className="h-5 w-5" />} label="History" href="/history" />
+
         {/* Center Camera Button */}
         <Link href="/upload">
           <button className="-mt-6 flex h-14 w-14 items-center justify-center rounded-full bg-[#F9A8C9] shadow-lg shadow-[#F9A8C9]/40 transition-transform hover:scale-105 active:scale-95">
@@ -51,14 +55,22 @@ export function BottomNav() {
             <span className="sr-only">Take Photo</span>
           </button>
         </Link>
-        
+
         <NavItem
           icon={<Sparkles className="h-5 w-5" />}
           label="Style"
           href="/style"
           badge="Beta"
         />
-        <NavItem icon={<User className="h-5 w-5" />} label="Profile" href="/profile"/>
+
+        {/* Profile / login — href 분기 */}
+        <Link
+          href={profileHref}
+          className="flex flex-col items-center gap-1 text-muted-foreground transition-colors"
+        >
+          <User className="h-5 w-5" />
+          <span className="text-[10px] font-medium">{user ? "profile" : "login"}</span>
+        </Link>
       </div>
     </nav>
   )

--- a/frontend/src/components/desktop-sidebar.tsx
+++ b/frontend/src/components/desktop-sidebar.tsx
@@ -6,6 +6,7 @@ import { Home, History, Camera, Sparkles, User, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { useAuth } from "@/hooks/useAuth"
 
 interface SidebarItemProps {
   icon: React.ReactNode
@@ -39,6 +40,8 @@ function SidebarItem({ icon, label, href, badge }: SidebarItemProps) {
 }
 
 export function DesktopSidebar() {
+  const { user, loading, logout } = useAuth()
+
   return (
     <aside className="hidden lg:flex lg:w-64 lg:flex-col lg:border-r lg:border-border/50 lg:bg-white">
       <div className="flex h-16 items-center px-6">
@@ -51,16 +54,31 @@ export function DesktopSidebar() {
         <SidebarItem icon={<Home className="h-5 w-5" />} label="Home" href="/" />
         <SidebarItem icon={<History className="h-5 w-5" />} label="History" href="/history" />
         <SidebarItem icon={<Sparkles className="h-5 w-5" />} label="Style" href="/style" badge="Beta" />
-        <SidebarItem icon={<User className="h-5 w-5" />} label="Profile" href="/profile" />
+        <SidebarItem icon={<User className="h-5 w-5" />} label={user ? "profile" : "login"} href={user ? "/profile" : `${process.env.NEXT_PUBLIC_API_URL}/auth/login`} />
         <SidebarItem icon={<Settings className="h-5 w-5" />} label="Settings" href="/settings" />
 
-        <div className="mt-auto">
+        <div className="mt-auto space-y-3">
           <Link href="/upload">
             <Button className="w-full rounded-xl bg-[#F9A8C9] py-6 text-sm font-semibold text-white shadow-lg shadow-[#F9A8C9]/30 transition-all hover:bg-[#F490B8]">
               <Camera className="mr-2 h-5 w-5" />
               Start Analysis
             </Button>
           </Link>
+
+          {!loading && user && (
+            <div className="flex items-center justify-between rounded-xl bg-muted/50 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">{user.name}</p>
+                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+              </div>
+              <button
+                onClick={logout}
+                className="ml-2 shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                logout
+              </button>
+            </div>
+          )}
         </div>
       </nav>
     </aside>

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,19 +1,33 @@
 "use client"
 
+import Link from "next/link"
 import { Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { useAuth } from "@/hooks/useAuth"
 
 export function Header() {
+  const { user, loading } = useAuth()
+
   return (
     <header className="flex items-center justify-between px-5 py-4">
       <h1 className="text-2xl font-bold tracking-tight text-foreground">
         project
       </h1>
-      <Button variant="ghost" size="icon" className="relative">
-        <Bell className="h-5 w-5 text-muted-foreground" />
-        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
-        <span className="sr-only">Notifications</span>
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell className="h-5 w-5 text-muted-foreground" />
+          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-primary" />
+          <span className="sr-only">Notifications</span>
+        </Button>
+        {!loading && (
+          <Link
+            href={user ? "/profile" : `${process.env.NEXT_PUBLIC_API_URL}/auth/login`}
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {user ? user.name.split(" ")[0] : "login"}
+          </Link>
+        )}
+      </div>
     </header>
   )
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState, useEffect } from "react"
+
+export interface AuthUser {
+  id: string
+  email: string
+  name: string
+  picture: string | null
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/me`, { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => setUser(data?.user ?? null))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const logout = async () => {
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/logout`, {
+      method: "POST",
+      credentials: "include",
+    })
+    setUser(null)
+  }
+
+  return { user, loading, logout }
+}


### PR DESCRIPTION
## Summary
- Add Google OAuth2 endpoints (`/auth/login`, `/auth/google/callback`, `/auth/me`, `/auth/logout`)
- Add `users` and `analysis_history` tables with Alembic migration (002)
- JWT-based session via httpOnly cookie
- Auto-save analysis results when user is logged in
- Responsive login/profile state in header, bottom nav, and sidebar
- Add profile page (`/profile`)

## Test plan
- [x] Google login → consent screen → redirect works correctly
- [x] Header, bottom nav, sidebar show user name/profile after login
- [ ] Analysis without login does not save to `analysis_history`
- [x] Analysis with login saves record to DB
- [x] Logout clears cookie and resets UI
- [x] Accessing `/profile` without login redirects to login page
