### PR TITLE
feat: analysis history API integration and save button auth fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ frontend/.next/
 # Docker
 postgres_data/
 
+# Uploaded images (keep directory via .gitkeep)
+backend/uploads/*
+!backend/uploads/.gitkeep
+
 # macOS
 .DS_Store
 

--- a/backend/alembic/versions/003_add_image_landmarks_to_history.py
+++ b/backend/alembic/versions/003_add_image_landmarks_to_history.py
@@ -1,0 +1,34 @@
+"""add image and landmarks columns to analysis_history
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-05-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("""
+        ALTER TABLE analysis_history
+            ADD COLUMN IF NOT EXISTS image_filename VARCHAR,
+            ADD COLUMN IF NOT EXISTS landmarks      JSON,
+            ADD COLUMN IF NOT EXISTS image_size     JSON
+    """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("""
+        ALTER TABLE analysis_history
+            DROP COLUMN IF EXISTS image_filename,
+            DROP COLUMN IF EXISTS landmarks,
+            DROP COLUMN IF EXISTS image_size
+    """))

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -83,6 +83,9 @@ class AnalysisHistory(Base):
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     skin_scores = Column(JSON)
     skin_type = Column(String)
+    image_filename = Column(String)
+    landmarks = Column(JSON)
+    image_size = Column(JSON)
     analyzed_at = Column(DateTime, default=datetime.now)
 
     user = relationship("User", back_populates="analysis_history")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,14 @@
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from routers import analyze, recommend, auth
 
 app = FastAPI(title='face')
+
+UPLOADS_DIR = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOADS_DIR, exist_ok=True)
+app.mount("/uploads", StaticFiles(directory=UPLOADS_DIR), name="uploads")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -19,6 +19,34 @@ MAX_SIZE = 10 * 1024 * 1024
 def analyze_health():
     return {"message": "analyze router ok"}
 
+@router.get("/history")
+def get_history(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    from fastapi import HTTPException
+    if not current_user:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
+    from sqlalchemy import desc
+    records = (
+        db.query(AnalysisHistory)
+        .filter(AnalysisHistory.user_id == current_user["id"])
+        .order_by(desc(AnalysisHistory.analyzed_at))
+        .all()
+    )
+
+    return [
+        {
+            "id": r.id,
+            "skin_type": r.skin_type,
+            "overall_score": round((r.skin_scores or {}).get("overall", 0), 1),
+            "skin_scores": r.skin_scores,
+            "analyzed_at": r.analyzed_at.isoformat(),
+        }
+        for r in records
+    ]
+
 @router.post("/")
 async def analyze_skin(
     file: UploadFile = File(...),

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -1,4 +1,4 @@
-import uuid, os
+import uuid, os, shutil
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from sqlalchemy.orm import Session
 from db.session import get_db
@@ -14,6 +14,7 @@ router = APIRouter()
 
 ALLOWED_TYPES = ["image/jpeg", "image/png", "image/heic", "image/webp"]
 MAX_SIZE = 10 * 1024 * 1024
+UPLOADS_DIR = os.path.join(os.path.dirname(__file__), "..", "uploads")
 
 @router.get("/")
 def analyze_health():
@@ -36,6 +37,7 @@ def get_history(
         .all()
     )
 
+    base_url = "http://localhost:8000"
     return [
         {
             "id": r.id,
@@ -43,6 +45,9 @@ def get_history(
             "overall_score": round((r.skin_scores or {}).get("overall", 0), 1),
             "skin_scores": r.skin_scores,
             "analyzed_at": r.analyzed_at.isoformat(),
+            "image_url": f"{base_url}/uploads/{r.image_filename}" if r.image_filename else None,
+            "landmarks": r.landmarks or [],
+            "image_size": r.image_size or {"width": 1, "height": 1},
         }
         for r in records
     ]
@@ -61,12 +66,15 @@ async def analyze_skin(
     if len(contents) > MAX_SIZE:
         raise HTTPException(status_code=400, detail="파일 크기는 10MB 이하여야 합니다.")
 
+    record_id = str(uuid.uuid4())
     suffix = os.path.splitext(file.filename)[1]
-    tmp_path = f"/tmp/{uuid.uuid4()}{suffix}"
+    tmp_path = f"/tmp/{record_id}{suffix}"
+    upload_filename = f"{record_id}{suffix}"
+    upload_path = os.path.join(UPLOADS_DIR, upload_filename)
 
     with open(tmp_path, "wb") as f:
         f.write(contents)
-    
+
     try:
         # 1. 랜드마크 추출
         landmarks = extract_landmarks(tmp_path)
@@ -132,11 +140,15 @@ async def analyze_skin(
             p["reason"] = reason
 
         if current_user:
+            shutil.copy2(tmp_path, upload_path)
             db.add(AnalysisHistory(
-                id=str(uuid.uuid4()),
+                id=record_id,
                 user_id=current_user["id"],
                 skin_scores=scores,
                 skin_type=skin_type,
+                image_filename=upload_filename,
+                landmarks=landmarks["landmarks"],
+                image_size=landmarks["image_size"],
                 analyzed_at=datetime.now(),
             ))
             db.commit()

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import {
   LineChart,
   Line,
@@ -15,262 +15,294 @@ import { DesktopSidebar } from "@/components/desktop-sidebar"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import Link from "next/link"
+import { getHistory } from "@/lib/api"
+import { HistoryItem } from "@/types/api"
 
 const months = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December"
 ]
 
-const analysisData = [
-  { date: "Apr 1", score: 72 },
-  { date: "Apr 5", score: 74 },
-  { date: "Apr 10", score: 71 },
-  { date: "Apr 15", score: 76 },
-  { date: "Apr 18", score: 78 },
-  { date: "Apr 22", score: 75 },
-  { date: "Apr 27", score: 77 },
-]
+function formatDateShort(iso: string) {
+  const d = new Date(iso)
+  return `${months[d.getMonth()].slice(0, 3)} ${d.getDate()}`
+}
 
-const recentAnalyses = [
-  {
-    id: 1,
-    date: "April 27, 2026",
-    score: 77,
-    summary: "Improved brightness detected. Redness slightly reduced compared to last week.",
-  },
-  {
-    id: 2,
-    date: "April 22, 2026",
-    score: 75,
-    summary: "Moisture levels stable. Consider adding hydrating products to your routine.",
-  },
-  {
-    id: 3,
-    date: "April 18, 2026",
-    score: 78,
-    summary: "Best score this month! Skin tone is evening out nicely.",
-  },
-  {
-    id: 4,
-    date: "April 15, 2026",
-    score: 76,
-    summary: "Minor trouble spots detected. Recommend gentle cleansing routine.",
-  },
-]
+function formatDateLong(iso: string) {
+  const d = new Date(iso)
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
+}
 
-const daysWithAnalysis = [1, 5, 10, 15, 18, 22, 27]
+function getSkinTypeSummary(skin_type: string, overall_score: number): string {
+  const typeMap: Record<string, string> = {
+    dry: "건조한 피부 상태입니다. 보습 관리에 신경써주세요.",
+    oily: "피지 분비가 활발합니다. 유분 조절이 필요합니다.",
+    sensitive: "피부 자극에 주의가 필요합니다. 진정 케어를 추천합니다.",
+    combination: "복합성 피부입니다. 부위별 맞춤 케어가 효과적입니다.",
+  }
+  const base = typeMap[skin_type] ?? "피부 분석이 완료되었습니다."
+  if (overall_score >= 75) return `컨디션이 좋습니다. ${base}`
+  if (overall_score >= 50) return `보통 컨디션입니다. ${base}`
+  return `관리가 필요한 상태입니다. ${base}`
+}
 
 export default function HistoryPage() {
-  const [currentMonth, setCurrentMonth] = useState(3)
-  const [currentYear] = useState(2026)
-  const [hasHistory] = useState(true)
+  const [history, setHistory] = useState<HistoryItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [isLoggedOut, setIsLoggedOut] = useState(false)
+  const [currentMonth, setCurrentMonth] = useState(new Date().getMonth())
+  const [currentYear, setCurrentYear] = useState(new Date().getFullYear())
+
+  useEffect(() => {
+    getHistory()
+      .then(setHistory)
+      .catch((e: Error) => {
+        if (e.message.includes("로그인")) setIsLoggedOut(true)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const prevMonth = () => {
+    if (currentMonth === 0) { setCurrentMonth(11); setCurrentYear(y => y - 1) }
+    else setCurrentMonth(m => m - 1)
+  }
+  const nextMonth = () => {
+    if (currentMonth === 11) { setCurrentMonth(0); setCurrentYear(y => y + 1) }
+    else setCurrentMonth(m => m + 1)
+  }
+
+  // 현재 뷰 월의 분석 날짜 목록
+  const daysWithAnalysis = history
+    .filter(r => {
+      const d = new Date(r.analyzed_at)
+      return d.getMonth() === currentMonth && d.getFullYear() === currentYear
+    })
+    .map(r => new Date(r.analyzed_at).getDate())
 
   const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate()
   const days = Array.from({ length: daysInMonth }, (_, i) => i + 1)
+  const today = new Date()
 
-  const prevMonth = () => {
-    setCurrentMonth((prev) => (prev === 0 ? 11 : prev - 1))
-  }
+  // 차트용: 최신 10개, 날짜 오름차순
+  const chartData = [...history]
+    .slice(0, 10)
+    .reverse()
+    .map(r => ({ date: formatDateShort(r.analyzed_at), score: r.overall_score }))
 
-  const nextMonth = () => {
-    setCurrentMonth((prev) => (prev === 11 ? 0 : prev + 1))
-  }
+  const avg = history.length
+    ? Math.round(history.reduce((s, r) => s + r.overall_score, 0) / history.length)
+    : 0
+  const best = history.length ? Math.max(...history.map(r => r.overall_score)) : 0
+  const trend = history.length >= 2
+    ? ((history[0].overall_score - history[history.length - 1].overall_score) /
+        history[history.length - 1].overall_score * 100).toFixed(1)
+    : null
 
-  if (!hasHistory) {
-    return (
-      <div className="flex min-h-screen bg-background">
-        <DesktopSidebar />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
-            <div className="px-4 py-4">
-              <h1 className="text-xl font-semibold text-foreground">My Skin Journey</h1>
-            </div>
-          </header>
-
-          <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
-            <div className="w-24 h-24 rounded-full bg-[#F9A8C9]/10 flex items-center justify-center mb-6">
-              <Calendar className="w-12 h-12 text-[#F9A8C9]" />
-            </div>
-            <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
-              No History Yet
-            </h2>
-            <p className="text-muted-foreground text-center mb-8 max-w-xs">
-              Start your first skin analysis to begin tracking your skin journey over time.
-            </p>
-            <Link href="/upload">
-              <Button className="bg-[#F9A8C9] hover:bg-[#F9A8C9]/90 text-white rounded-full px-8 py-6 text-base font-medium">
-                <Camera className="w-5 h-5 mr-2" />
-                Start First Analysis
-              </Button>
-            </Link>
-          </main>
-
-          <BottomNav activeTab="history" />
-        </div>
+  const EmptyOrLogout = (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4">
+            <h1 className="text-xl font-semibold text-foreground">My Skin Journey</h1>
+          </div>
+        </header>
+        <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
+          <div className="w-24 h-24 rounded-full bg-[#F9A8C9]/10 flex items-center justify-center mb-6">
+            <Calendar className="w-12 h-12 text-[#F9A8C9]" />
+          </div>
+          <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
+            {isLoggedOut ? "로그인이 필요합니다" : "No History Yet"}
+          </h2>
+          <p className="text-muted-foreground text-center mb-8 max-w-xs">
+            {isLoggedOut
+              ? "히스토리를 보려면 로그인 후 분석을 진행해주세요."
+              : "Start your first skin analysis to begin tracking your skin journey over time."}
+          </p>
+          <Link href="/upload">
+            <Button className="bg-[#F9A8C9] hover:bg-[#F9A8C9]/90 text-white rounded-full px-8 py-6 text-base font-medium">
+              <Camera className="w-5 h-5 mr-2" />
+              {isLoggedOut ? "분석 시작하기" : "Start First Analysis"}
+            </Button>
+          </Link>
+        </main>
+        <BottomNav activeTab="history" />
       </div>
-    )
-  }
+    </div>
+  )
+
+  if (loading) return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col items-center justify-center">
+        <div className="w-8 h-8 rounded-full border-2 border-[#F9A8C9] border-t-transparent animate-spin" />
+      </div>
+    </div>
+  )
+
+  if (isLoggedOut || history.length === 0) return EmptyOrLogout
 
   return (
     <div className="flex min-h-screen bg-background">
       <DesktopSidebar />
       <div className="flex min-w-0 flex-1 flex-col pb-24">
-      <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
-        <div className="px-4 py-4">
-          <h1 className="text-xl font-semibold text-foreground">My Skin Journey</h1>
-        </div>
-      </header>
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4">
+            <h1 className="text-xl font-semibold text-foreground">My Skin Journey</h1>
+          </div>
+        </header>
 
-      <main className="px-4 py-6 space-y-6">
-        {/* Monthly Calendar Strip */}
-        <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
-          <div className="flex items-center justify-between mb-4">
-            <button
-              onClick={prevMonth}
-              className="p-2 rounded-full hover:bg-muted transition-colors"
-              aria-label="Previous month"
-            >
-              <ChevronLeft className="w-5 h-5 text-muted-foreground" />
-            </button>
-            <h2 className="font-semibold text-foreground">
-              {months[currentMonth]} {currentYear}
-            </h2>
-            <button
-              onClick={nextMonth}
-              className="p-2 rounded-full hover:bg-muted transition-colors"
-              aria-label="Next month"
-            >
-              <ChevronRight className="w-5 h-5 text-muted-foreground" />
-            </button>
-          </div>
+        <main className="px-4 py-6 space-y-6">
+          {/* Monthly Calendar Strip */}
+          <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
+            <div className="flex items-center justify-between mb-4">
+              <button
+                onClick={prevMonth}
+                className="p-2 rounded-full hover:bg-muted transition-colors"
+                aria-label="Previous month"
+              >
+                <ChevronLeft className="w-5 h-5 text-muted-foreground" />
+              </button>
+              <h2 className="font-semibold text-foreground">
+                {months[currentMonth]} {currentYear}
+              </h2>
+              <button
+                onClick={nextMonth}
+                className="p-2 rounded-full hover:bg-muted transition-colors"
+                aria-label="Next month"
+              >
+                <ChevronRight className="w-5 h-5 text-muted-foreground" />
+              </button>
+            </div>
 
-          <div className="overflow-x-auto scrollbar-hide -mx-2 px-2">
-            <div className="flex gap-2 min-w-max pb-2">
-              {days.map((day) => {
-                const hasAnalysis = daysWithAnalysis.includes(day)
-                const isToday = day === 27 && currentMonth === 3
-                return (
-                  <button
-                    key={day}
-                    className={`
-                      flex flex-col items-center justify-center w-11 h-14 rounded-xl transition-all
-                      ${hasAnalysis ? "bg-[#F9A8C9]/10" : "bg-transparent"}
-                      ${isToday ? "ring-2 ring-[#F9A8C9]" : ""}
-                      hover:bg-[#F9A8C9]/5
-                    `}
-                  >
-                    <span className={`text-sm font-medium ${isToday ? "text-[#F9A8C9]" : "text-foreground"}`}>
-                      {day}
-                    </span>
-                    {hasAnalysis && (
-                      <div className="w-1.5 h-1.5 rounded-full bg-[#F9A8C9] mt-1" />
-                    )}
-                  </button>
-                )
-              })}
+            <div className="overflow-x-auto scrollbar-hide -mx-2 px-2">
+              <div className="flex gap-2 min-w-max pb-2">
+                {days.map((day) => {
+                  const hasAnalysis = daysWithAnalysis.includes(day)
+                  const isToday =
+                    day === today.getDate() &&
+                    currentMonth === today.getMonth() &&
+                    currentYear === today.getFullYear()
+                  return (
+                    <button
+                      key={day}
+                      className={`
+                        flex flex-col items-center justify-center w-11 h-14 rounded-xl transition-all
+                        ${hasAnalysis ? "bg-[#F9A8C9]/10" : "bg-transparent"}
+                        ${isToday ? "ring-2 ring-[#F9A8C9]" : ""}
+                        hover:bg-[#F9A8C9]/5
+                      `}
+                    >
+                      <span className={`text-sm font-medium ${isToday ? "text-[#F9A8C9]" : "text-foreground"}`}>
+                        {day}
+                      </span>
+                      {hasAnalysis && (
+                        <div className="w-1.5 h-1.5 rounded-full bg-[#F9A8C9] mt-1" />
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
 
-        {/* Skin Trend Chart */}
-        <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
-          <div className="flex items-center gap-2 mb-4">
-            <TrendingUp className="w-5 h-5 text-[#F9A8C9]" />
-            <h2 className="font-semibold text-foreground">Skin Score Trend</h2>
-          </div>
-          <div className="h-48">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={analysisData} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="pinkGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#F9A8C9" stopOpacity={0.3} />
-                    <stop offset="100%" stopColor="#F9A8C9" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <XAxis
-                  dataKey="date"
-                  axisLine={false}
-                  tickLine={false}
-                  tick={{ fill: "#9CA3AF", fontSize: 12 }}
-                />
-                <YAxis
-                  domain={[60, 100]}
-                  axisLine={false}
-                  tickLine={false}
-                  tick={{ fill: "#9CA3AF", fontSize: 12 }}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #E5E7EB",
-                    borderRadius: "12px",
-                    boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-                  }}
-                  labelStyle={{ color: "#374151", fontWeight: 600 }}
-                  itemStyle={{ color: "#F9A8C9" }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="score"
-                  stroke="#F9A8C9"
-                  strokeWidth={3}
-                  dot={{ fill: "#F9A8C9", strokeWidth: 0, r: 4 }}
-                  activeDot={{ fill: "#F9A8C9", strokeWidth: 0, r: 6 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-          <div className="flex items-center justify-center gap-6 mt-4 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Average:</span>
-              <span className="font-semibold text-foreground">75</span>
+          {/* Skin Trend Chart */}
+          <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
+            <div className="flex items-center gap-2 mb-4">
+              <TrendingUp className="w-5 h-5 text-[#F9A8C9]" />
+              <h2 className="font-semibold text-foreground">Skin Score Trend</h2>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Best:</span>
-              <span className="font-semibold text-green-600">78</span>
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={chartData} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="pinkGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#F9A8C9" stopOpacity={0.3} />
+                      <stop offset="100%" stopColor="#F9A8C9" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <XAxis
+                    dataKey="date"
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: "#9CA3AF", fontSize: 12 }}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: "#9CA3AF", fontSize: 12 }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "white",
+                      border: "1px solid #E5E7EB",
+                      borderRadius: "12px",
+                      boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                    }}
+                    labelStyle={{ color: "#374151", fontWeight: 600 }}
+                    itemStyle={{ color: "#F9A8C9" }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="score"
+                    stroke="#F9A8C9"
+                    strokeWidth={3}
+                    dot={{ fill: "#F9A8C9", strokeWidth: 0, r: 4 }}
+                    activeDot={{ fill: "#F9A8C9", strokeWidth: 0, r: 6 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Trend:</span>
-              <span className="font-semibold text-[#F9A8C9]">+5%</span>
+            <div className="flex items-center justify-center gap-6 mt-4 text-sm">
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">Average:</span>
+                <span className="font-semibold text-foreground">{avg}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">Best:</span>
+                <span className="font-semibold text-green-600">{best}</span>
+              </div>
+              {trend !== null && (
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Trend:</span>
+                  <span className={`font-semibold ${Number(trend) >= 0 ? "text-[#F9A8C9]" : "text-red-400"}`}>
+                    {Number(trend) >= 0 ? "+" : ""}{trend}%
+                  </span>
+                </div>
+              )}
             </div>
-          </div>
-        </Card>
+          </Card>
 
-        {/* Recent Analyses */}
-        <div>
-          <h2 className="font-semibold text-foreground mb-4">Recent Analyses</h2>
-          <div className="space-y-3">
-            {recentAnalyses.map((analysis) => (
-              <Link key={analysis.id} href="/results">
-                <Card className="p-4 rounded-2xl border-border/50 shadow-sm hover:shadow-md transition-shadow">
+          {/* Recent Analyses */}
+          <div>
+            <h2 className="font-semibold text-foreground mb-4">Recent Analyses</h2>
+            <div className="space-y-3">
+              {history.slice(0, 10).map((item) => (
+                <Card key={item.id} className="p-4 rounded-2xl border-border/50 shadow-sm">
                   <div className="flex gap-4">
-                    {/* Thumbnail placeholder */}
                     <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-[#F9A8C9]/20 to-[#C4B5FD]/20 flex items-center justify-center flex-shrink-0">
-                      <div className="w-10 h-10 rounded-full bg-[#F9A8C9]/30 flex items-center justify-center">
-                        <div className="w-6 h-6 rounded-full bg-[#F9A8C9]/50" />
-                      </div>
+                      <span className="text-xl font-bold text-[#F9A8C9]">{Math.round(item.overall_score)}</span>
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm text-muted-foreground">{analysis.date}</span>
-                        <div className="flex items-center gap-1">
-                          <span className="text-lg font-bold text-foreground">{analysis.score}</span>
-                          <span className="text-xs text-muted-foreground">/100</span>
-                        </div>
+                        <span className="text-sm text-muted-foreground">{formatDateLong(item.analyzed_at)}</span>
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-[#F9A8C9]/10 text-[#F9A8C9] font-medium">
+                          {item.skin_type}
+                        </span>
                       </div>
                       <p className="text-sm text-foreground/80 line-clamp-2">
-                        {analysis.summary}
+                        {getSkinTypeSummary(item.skin_type, item.overall_score)}
                       </p>
                     </div>
                   </div>
                 </Card>
-              </Link>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      </main>
+        </main>
 
-      <BottomNav activeTab="history" />
+        <BottomNav activeTab="history" />
       </div>
     </div>
   )

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -15,6 +15,7 @@ import { DesktopSidebar } from "@/components/desktop-sidebar"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { getHistory } from "@/lib/api"
 import { HistoryItem } from "@/types/api"
 
@@ -47,6 +48,7 @@ function getSkinTypeSummary(skin_type: string, overall_score: number): string {
 }
 
 export default function HistoryPage() {
+  const router = useRouter()
   const [history, setHistory] = useState<HistoryItem[]>([])
   const [loading, setLoading] = useState(true)
   const [isLoggedOut, setIsLoggedOut] = useState(false)
@@ -279,9 +281,24 @@ export default function HistoryPage() {
             <h2 className="font-semibold text-foreground mb-4">Recent Analyses</h2>
             <div className="space-y-3">
               {history.slice(0, 10).map((item) => (
-                <Card key={item.id} className="p-4 rounded-2xl border-border/50 shadow-sm">
+                <Card
+                  key={item.id}
+                  className="p-4 rounded-2xl border-border/50 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+                  onClick={() => {
+                    const data = {
+                      skin_scores: item.skin_scores,
+                      skin_type: item.skin_type,
+                      products: [],
+                      analyzed_at: item.analyzed_at,
+                      image_url: item.image_url,
+                      landmarks: item.landmarks,
+                      image_size: item.image_size,
+                    }
+                    router.push(`/result?data=${encodeURIComponent(JSON.stringify(data))}`)
+                  }}
+                >
                   <div className="flex gap-4">
-                    <div className="w-16 h-16 rounded-xl bg-gradient-to-br from-[#F9A8C9]/20 to-[#C4B5FD]/20 flex items-center justify-center flex-shrink-0">
+                    <div className="w-16 h-16 rounded-xl bg-linear-to-br from-[#F9A8C9]/20 to-[#C4B5FD]/20 flex items-center justify-center shrink-0">
                       <span className="text-xl font-bold text-[#F9A8C9]">{Math.round(item.overall_score)}</span>
                     </div>
                     <div className="flex-1 min-w-0">

--- a/frontend/src/app/result/page.tsx
+++ b/frontend/src/app/result/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { useState } from "react"
-import { useSearchParams } from "next/navigation"
+import { useSearchParams, useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { AnalyzeResponse } from "@/types/api"
 import { ChevronLeft, Calendar, Bookmark, LogIn, TrendingUp } from "lucide-react"
 import Link from "next/link"
+import { useAuth } from "@/hooks/useAuth"
 import {
   Radar,
   RadarChart,
@@ -88,10 +89,10 @@ function RecommendedProductCard({
 
 export default function ResultsPage() {
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const { user } = useAuth()
   const [analysisData, setAnalysisData] = useState<AnalyzeResponse | null>(null)
   const [uploadedImage, setUploadedImage] = useState<string | null>(null)
-
-  const [isLoggedIn] = useState(false)
   const [showLoginDialog, setShowLoginDialog] = useState(false)
 
   const faceLandmarks = analysisData?.landmarks?.map(([x, y]) => ({
@@ -101,7 +102,9 @@ export default function ResultsPage() {
 
   
   const handleSave = () => {
-    if (!isLoggedIn) {
+    if (user) {
+      router.push("/history")
+    } else {
       setShowLoginDialog(true)
     }
   }
@@ -189,7 +192,7 @@ export default function ResultsPage() {
               className="hidden items-center gap-2 rounded-full border-[#F9A8C9] px-5 text-[#F9A8C9] hover:bg-[#F9A8C9]/10 hover:text-[#F9A8C9] lg:flex"
             >
               <Bookmark className="h-4 w-4" />
-              Save Results
+              {user ? "View History" : "Save Results"}
             </Button>
           </div>
         </header>
@@ -397,7 +400,7 @@ export default function ResultsPage() {
                 className="w-full rounded-full border-[#F9A8C9] py-6 text-[#F9A8C9] hover:bg-[#F9A8C9]/10 hover:text-[#F9A8C9] lg:hidden"
               >
                 <Bookmark className="mr-2 h-5 w-5" />
-                Save Results
+                {user ? "View History" : "Save Results"}
               </Button>
             </div>
           </div>

--- a/frontend/src/app/result/page.tsx
+++ b/frontend/src/app/result/page.tsx
@@ -95,10 +95,7 @@ export default function ResultsPage() {
   const [uploadedImage, setUploadedImage] = useState<string | null>(null)
   const [showLoginDialog, setShowLoginDialog] = useState(false)
 
-  const faceLandmarks = analysisData?.landmarks?.map(([x, y]) => ({
-    x: (x / (analysisData.image_size?.width || 1)) * 100,
-    y: (y / (analysisData.image_size?.height || 1)) * 100,
-  })) || []
+
 
   
   const handleSave = () => {
@@ -120,12 +117,17 @@ export default function ResultsPage() {
   useEffect(() => {
     const data = searchParams.get("data")
     if (data) {
-        try {
-          setAnalysisData(JSON.parse(data))
-        } catch (e) {
-          console.error("Failed to parse analysis data")
+      try {
+        const parsed = JSON.parse(data)
+        setAnalysisData(parsed)
+        if (parsed.image_url) {
+          setUploadedImage(parsed.image_url)
+          return
         }
+      } catch (e) {
+        console.error("Failed to parse analysis data")
       }
+    }
     const savedImage = sessionStorage.getItem('analysisImage')
     if (savedImage) {
       setUploadedImage(savedImage)
@@ -224,7 +226,7 @@ export default function ResultsPage() {
       )}
 
       {/* SVG 오버레이 */}
-      {uploadedImage && analysisData?.landmarks && (
+      {uploadedImage && analysisData?.landmarks && analysisData.landmarks.length > 0 && (
         <svg
           className="absolute inset-0 w-full h-full"
           viewBox={`0 0 ${analysisData.image_size.width} ${analysisData.image_size.height}`}
@@ -306,6 +308,16 @@ export default function ResultsPage() {
 
 
 
+              {/* Skin type badge - mobile only */}
+              {analysisData?.skin_type && (
+                <div className="flex items-center gap-2 lg:hidden">
+                  <span className="px-3 py-1 rounded-full text-xs font-medium bg-[#F9A8C9]/15 text-[#F9A8C9] capitalize">
+                    {analysisData.skin_type} skin
+                  </span>
+                  <span className="text-sm text-muted-foreground">Overall: <span className="font-semibold text-foreground">{overallScore}</span>/100</span>
+                </div>
+              )}
+
               {/* Score cards */}
               <div className="grid grid-cols-4 gap-2 lg:grid-cols-2 lg:gap-3">
                 {scoreMetrics.map((metric) => (
@@ -331,9 +343,11 @@ export default function ResultsPage() {
                       <span className="text-5xl font-bold text-foreground">{overallScore}</span>
                       <span className="text-lg text-muted-foreground">/100</span>
                     </div>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Good condition — keep up your routine!
-                    </p>
+                    {analysisData?.skin_type && (
+                      <span className="mt-2 inline-block px-3 py-1 rounded-full text-xs font-medium bg-white text-[#F9A8C9] shadow-sm capitalize">
+                        {analysisData.skin_type} skin
+                      </span>
+                    )}
                   </div>
                   <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white shadow-sm">
                     <TrendingUp className="h-9 w-9 text-[#F9A8C9]" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { AnalyzeResponse } from "@/types/api";
+import { AnalyzeResponse, HistoryItem } from "@/types/api";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
@@ -8,6 +8,7 @@ export async function analyzeImage(file: File): Promise<AnalyzeResponse> {
 
     const res = await fetch(`${API_BASE_URL}/analyze/`, {
         method: 'POST',
+        credentials: 'include',
         body: formData
     })
 
@@ -19,8 +20,10 @@ export async function analyzeImage(file: File): Promise<AnalyzeResponse> {
     return res.json()
 }
 
-export async function getHistory() {
-    const res = await fetch(`${API_BASE_URL}/history/`)
+export async function getHistory(): Promise<HistoryItem[]> {
+    const res = await fetch(`${API_BASE_URL}/analyze/history`, {
+        credentials: 'include',
+    })
 
     if (!res.ok) {
         const error = await res.json()

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -41,6 +41,15 @@ export interface AnalyzeResponse {
   image_size: { width: number, height: number } 
 }
 
+// 히스토리 항목
+export interface HistoryItem {
+  id: string
+  skin_type: string
+  overall_score: number
+  skin_scores: SkinScores
+  analyzed_at: string
+}
+
 // 에러 응답
 export interface ApiError {
   detail: string

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -48,6 +48,9 @@ export interface HistoryItem {
   overall_score: number
   skin_scores: SkinScores
   analyzed_at: string
+  image_url: string | null
+  landmarks: [number, number][]
+  image_size: { width: number; height: number }
 }
 
 // 에러 응답


### PR DESCRIPTION
## Summary
- `GET /analyze/history` 엔드포인트 추가 — 로그인 유저의 분석 기록 반환 (overall score, skin scores, skin type, 이미지 URL, 랜드마크)
- 분석 이미지를 `uploads/` 에 영구 보관하고 FastAPI StaticFiles로 서빙
- `analysis_history` 테이블에 `image_filename`, `landmarks`, `image_size` 컬럼 추가 (migration 003)
- 프론트 fetch 전체에 `credentials: include` 추가 — 로그인 세션이 실제로 전달됨
- 히스토리 페이지 mock 데이터 제거, 실제 API 연결 (차트, 달력, 분석 목록)
- 히스토리 카드 클릭 시 이미지 + 랜드마크 오버레이 포함한 결과 페이지로 이동
- result 페이지 `isLoggedIn` 하드코딩 버그 수정 (`useAuth` 훅으로 교체)
- result 페이지에 피부 타입 뱃지 추가 (모바일/데스크탑)

## Test plan
- [ ] 로그인 후 분석 → `uploads/`에 이미지 저장되는지 확인
- [ ] `GET /analyze/history` 응답에 image_url, landmarks 포함 확인
- [ ] 히스토리 페이지 실제 데이터로 차트·달력 표시
- [ ] 히스토리 카드 클릭 → result 페이지에서 이미지 + 랜드마크 오버레이 표시
- [ ] 로그인 상태에서 Save 버튼 → "View History"로 표시되고 히스토리 페이지로 이동
- [ ] 비로그인 상태에서 Save 버튼 → 로그인 다이얼로그 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)
