### PR TITLE
[BE][FE] Lighting-based makeup recommendation (#36)

### DIFF
--- a/backend/data/hairstyles.json
+++ b/backend/data/hairstyles.json
@@ -1,136 +1,136 @@
 {
   "oval": {
-    "label_ko": "타원형",
-    "description_ko": "이상적인 비율의 얼굴형으로 대부분의 헤어스타일이 잘 어울립니다.",
+    "label": "Oval",
+    "description": "An ideally proportioned face shape that suits most hairstyles.",
     "styles": [
       {
-        "name": "레이어드 컷",
-        "name_ko": "레이어드 컷",
-        "reason": "자연스러운 볼륨감을 살려 균형 잡힌 얼굴을 더욱 돋보이게 합니다.",
+        "name": "Layered Cut",
+        "name": "Layered Cut",
+        "reason": "Natural volume enhances the balanced proportions of an oval face.",
         "length": "medium",
-        "tags": ["볼륨", "자연스러움", "versatile"]
+        "tags": ["volume", "natural", "versatile"]
       },
       {
-        "name": "웨이브 롱",
-        "name_ko": "웨이브 롱",
-        "reason": "부드러운 웨이브가 타원형 얼굴의 선을 따라 흘러 우아함을 강조합니다.",
+        "name": "Wavy Long",
+        "name": "Wavy Long",
+        "reason": "Soft waves flow along the lines of an oval face, adding elegance.",
         "length": "long",
-        "tags": ["우아함", "여성스러움", "볼륨"]
+        "tags": ["elegant", "feminine", "volume"]
       },
       {
-        "name": "숏 픽시컷",
-        "name_ko": "숏 픽시컷",
-        "reason": "균형 잡힌 이목구비를 그대로 드러내 세련된 인상을 줍니다.",
+        "name": "Short Pixie Cut",
+        "name": "Short Pixie Cut",
+        "reason": "Exposes the balanced features as-is, giving a chic impression.",
         "length": "short",
-        "tags": ["세련됨", "개성", "시크"]
+        "tags": ["chic", "bold", "stylish"]
       }
     ]
   },
   "round": {
-    "label_ko": "둥근형",
-    "description_ko": "얼굴 길이와 너비가 비슷한 타입으로 세로 방향으로 길어 보이는 스타일이 잘 어울립니다.",
+    "label": "Round",
+    "description": "A face shape where length and width are similar. Styles that elongate vertically work best.",
     "styles": [
       {
-        "name": "하이레이어드 롱",
-        "name_ko": "하이레이어드 롱",
-        "reason": "정수리 볼륨을 높여 얼굴이 길어 보이는 효과를 줍니다.",
+        "name": "High-Layered Long",
+        "name": "High-Layered Long",
+        "reason": "Crown volume makes the face appear longer and slimmer.",
         "length": "long",
-        "tags": ["슬림", "세로확장", "볼륨"]
+        "tags": ["slim", "elongating", "volume"]
       },
       {
-        "name": "사이드 파팅 스트레이트",
-        "name_ko": "사이드 파팅 스트레이트",
-        "reason": "옆 가르마로 얼굴 비대칭 효과를 줘 갸름해 보입니다.",
+        "name": "Side-Part Straight",
+        "name": "Side-Part Straight",
+        "reason": "A side part creates an asymmetric effect that slims the face.",
         "length": "medium",
-        "tags": ["갸름", "단정함", "깔끔"]
+        "tags": ["slimming", "neat", "clean"]
       },
       {
-        "name": "쉐기 컷",
-        "name_ko": "쉐기 컷",
-        "reason": "불규칙한 레이어가 얼굴 너비를 줄이고 세로 방향을 강조합니다.",
+        "name": "Shaggy Cut",
+        "name": "Shaggy Cut",
+        "reason": "Irregular layers reduce face width and emphasize the vertical line.",
         "length": "medium",
-        "tags": ["트렌디", "갸름", "개성"]
+        "tags": ["trendy", "slimming", "edgy"]
       }
     ]
   },
   "square": {
-    "label_ko": "각진형",
-    "description_ko": "이마·광대·턱의 너비가 비슷한 타입으로 부드럽고 곡선적인 스타일이 잘 어울립니다.",
+    "label": "Square",
+    "description": "A face shape where forehead, cheekbones, and jaw have similar widths. Soft, curved styles suit it best.",
     "styles": [
       {
-        "name": "소프트 웨이브 미디엄",
-        "name_ko": "소프트 웨이브 미디엄",
-        "reason": "부드러운 웨이브가 각진 턱선을 자연스럽게 감싸 여성스러운 인상을 줍니다.",
+        "name": "Soft Wave Medium",
+        "name": "Soft Wave Medium",
+        "reason": "Gentle waves naturally soften the angular jawline for a feminine look.",
         "length": "medium",
-        "tags": ["부드러움", "여성스러움", "커버"]
+        "tags": ["soft", "feminine", "coverage"]
       },
       {
-        "name": "사이드 뱅 롱",
-        "name_ko": "사이드 뱅 롱",
-        "reason": "사이드 뱅이 각진 이마 선을 가려 부드러운 인상을 만들어 줍니다.",
+        "name": "Side Bang Long",
+        "name": "Side Bang Long",
+        "reason": "Side bangs cover the angular forehead, creating a softer impression.",
         "length": "long",
-        "tags": ["커버", "부드러움", "여성스러움"]
+        "tags": ["coverage", "soft", "feminine"]
       },
       {
-        "name": "C컬 보브",
-        "name_ko": "C컬 보브",
-        "reason": "C컬이 턱선을 부드럽게 감싸 각진 인상을 완화시켜 줍니다.",
+        "name": "C-Curl Bob",
+        "name": "C-Curl Bob",
+        "reason": "C-curls wrap gently around the jawline, softening angular features.",
         "length": "short",
-        "tags": ["세련됨", "커버", "트렌디"]
+        "tags": ["chic", "coverage", "trendy"]
       }
     ]
   },
   "heart": {
-    "label_ko": "하트형",
-    "description_ko": "이마가 넓고 턱이 뾰족한 타입으로 아래쪽 볼륨을 강조하는 스타일이 잘 어울립니다.",
+    "label": "Heart",
+    "description": "A face shape with a wide forehead and pointed chin. Styles that add volume at the lower half work best.",
     "styles": [
       {
-        "name": "턱선 보브",
-        "name_ko": "턱선 보브",
-        "reason": "턱 선에서 끝나는 길이가 좁은 아래턱에 볼륨을 더해 균형을 맞춰줍니다.",
+        "name": "Chin-Length Bob",
+        "name": "Chin-Length Bob",
+        "reason": "Length that ends at the chin adds volume to the narrow jaw, balancing the face.",
         "length": "short",
-        "tags": ["균형", "볼륨", "귀여움"]
+        "tags": ["balance", "volume", "cute"]
       },
       {
-        "name": "사이드 파팅 웨이브",
-        "name_ko": "사이드 파팅 웨이브",
-        "reason": "옆 가르마로 넓은 이마를 커버하고, 웨이브가 아래 볼륨을 보완합니다.",
+        "name": "Side-Part Wave",
+        "name": "Side-Part Wave",
+        "reason": "A side part covers the wide forehead, while waves add volume at the lower face.",
         "length": "medium",
-        "tags": ["커버", "균형", "우아함"]
+        "tags": ["coverage", "balance", "elegant"]
       },
       {
-        "name": "레이어드 미디엄",
-        "name_ko": "레이어드 미디엄",
-        "reason": "아래쪽 레이어가 턱 주변 볼륨을 만들어 역삼각형을 자연스럽게 보완합니다.",
+        "name": "Layered Medium",
+        "name": "Layered Medium",
+        "reason": "Lower layers build volume around the jaw, naturally balancing the inverted triangle.",
         "length": "medium",
-        "tags": ["균형", "자연스러움", "볼륨"]
+        "tags": ["balance", "natural", "volume"]
       }
     ]
   },
   "long": {
-    "label_ko": "긴형",
-    "description_ko": "얼굴 길이가 너비보다 긴 타입으로 가로 방향으로 넓어 보이는 스타일이 잘 어울립니다.",
+    "label": "Long",
+    "description": "A face shape taller than it is wide. Styles that add width horizontally suit it best.",
     "styles": [
       {
-        "name": "볼륨 보브",
-        "name_ko": "볼륨 보브",
-        "reason": "양 옆 볼륨이 긴 얼굴에 가로 너비감을 주어 균형을 맞춰줍니다.",
+        "name": "Volume Bob",
+        "name": "Volume Bob",
+        "reason": "Side volume adds horizontal width to a long face, creating balance.",
         "length": "short",
-        "tags": ["균형", "볼륨", "귀여움"]
+        "tags": ["balance", "volume", "cute"]
       },
       {
-        "name": "뱅 미디엄",
-        "name_ko": "뱅 미디엄",
-        "reason": "앞머리가 긴 이마를 커버해 얼굴 세로 길이를 줄여주는 효과가 있습니다.",
+        "name": "Bang Medium",
+        "name": "Bang Medium",
+        "reason": "Bangs cover the long forehead, reducing the perceived vertical length of the face.",
         "length": "medium",
-        "tags": ["커버", "균형", "트렌디"]
+        "tags": ["coverage", "balance", "trendy"]
       },
       {
-        "name": "컬리 미디엄",
-        "name_ko": "컬리 미디엄",
-        "reason": "풍성한 컬이 가로 볼륨을 만들어 긴 얼굴을 균형있게 보이게 합니다.",
+        "name": "Curly Medium",
+        "name": "Curly Medium",
+        "reason": "Full curls create horizontal volume, making a long face look more balanced.",
         "length": "medium",
-        "tags": ["볼륨", "균형", "개성"]
+        "tags": ["volume", "balance", "bold"]
       }
     ]
   }

--- a/backend/data/makeup_palettes.json
+++ b/backend/data/makeup_palettes.json
@@ -1,0 +1,20 @@
+{
+  "bright": {
+    "dry":         { "foundation": "#F5DEB3", "blush": "#FFB6C1", "lip": "#FF6B8A", "eye": "#D4A5A5", "tip": "Use a dewy glow foundation for a radiant look, and add a pink blush for brightness." },
+    "oily":        { "foundation": "#E8C99A", "blush": "#FF8C69", "lip": "#C0392B", "eye": "#8B6F5E", "tip": "Control sebum with a matte foundation and finish cleanly with a nude lip." },
+    "sensitive":   { "foundation": "#F2DCC8", "blush": "#FADADD", "lip": "#E8A0A0", "eye": "#C8A882", "tip": "Use a fragrance-free mineral foundation and keep the look gentle with pastel tones." },
+    "combination": { "foundation": "#EDD5B3", "blush": "#FFB347", "lip": "#E05C6C", "eye": "#9B7B6A", "tip": "Apply matte foundation on the T-zone and a glow formula on the cheeks for zone-based control." }
+  },
+  "dark": {
+    "dry":         { "foundation": "#C8956C", "blush": "#8B4567", "lip": "#722F37", "eye": "#4A2040", "tip": "Use a hydrating serum foundation to prevent dryness and go dramatic with a deep burgundy lip." },
+    "oily":        { "foundation": "#B8864E", "blush": "#8B3A3A", "lip": "#6B1B1B", "eye": "#3D2B1F", "tip": "Boost staying power with a long-wear matte foundation and add depth with dark-tone eye shadow." },
+    "sensitive":   { "foundation": "#D4A882", "blush": "#B06070", "lip": "#9B4D5A", "eye": "#6B4C5E", "tip": "Choose low-irritation mineral products and keep the look subtle with a calm rose palette." },
+    "combination": { "foundation": "#C0956A", "blush": "#A0526A", "lip": "#8B2252", "eye": "#5C3A4A", "tip": "Focus on oil control by zone and complete a chic night look with cool-tone purple shades." }
+  },
+  "outdoor": {
+    "dry":         { "foundation": "#F0D0A0", "blush": "#FF9AA2", "lip": "#FF7F7F", "eye": "#B8860B", "tip": "SPF 50+ sun-care foundation is a must! Go for coral tones for a lively, healthy impression." },
+    "oily":        { "foundation": "#D4A870", "blush": "#FF7043", "lip": "#D84315", "eye": "#795548", "tip": "Stick to waterproof matte products and use earth tones for a natural, long-lasting outdoor look." },
+    "sensitive":   { "foundation": "#EED5B8", "blush": "#FFCCBC", "lip": "#FF8A65", "eye": "#A1887F", "tip": "Choose products with physical UV filters and go for a natural look that minimizes skin irritation." },
+    "combination": { "foundation": "#E0B888", "blush": "#FF8F00", "lip": "#E64A19", "eye": "#8D6E63", "tip": "Combine long-wear and SPF products for outdoor activities and complete an energetic look with coral-orange tones." }
+  }
+}

--- a/backend/data/seed.py
+++ b/backend/data/seed.py
@@ -11,13 +11,13 @@ from db.session import SessionLocal
 from db.models import Product, SkinType, SkinProfile, Base, Level
 from db.session import engine
 
-# 부적합 성분 리스트
+# Ingredients to avoid
 AVOID_INGREDIENTS = [
     "alcohol", "fragrance", "parfum", "sodium lauryl sulfate",
     "sodium laureth sulfate", "paraben", "formaldehyde"
 ]
 
-# 피부 컨디션별 회피 성분
+# Ingredients to avoid per skin condition
 CONDITION_AVOID = {
     "redness":    ["alcohol", "fragrance", "parfum"],
     "trouble":    ["sodium lauryl sulfate", "sodium laureth sulfate", "paraben"],
@@ -37,7 +37,7 @@ SKIN_TYPES = [
         "moisture_level": Level.low,
         "oil_level": Level.low,
         "sensitivity": Level.mid,
-        "description": "피부 수분이 부족하고 당김이 있는 건성 피부",
+        "description": "Dry skin with low moisture and a tight feeling.",
     },
     {
         "id": "oily",
@@ -45,7 +45,7 @@ SKIN_TYPES = [
         "moisture_level": Level.high,
         "oil_level": Level.high,
         "sensitivity": Level.low,
-        "description": "피지 분비가 많고 번들거리는 지성 피부",
+        "description": "Oily skin with high sebum production and a shiny appearance.",
     },
     {
         "id": "sensitive",
@@ -53,7 +53,7 @@ SKIN_TYPES = [
         "moisture_level": Level.mid,
         "oil_level": Level.mid,
         "sensitivity": Level.high,
-        "description": "외부 자극에 민감하게 반응하고 붉어짐이 잦은 민감성 피부",
+        "description": "Sensitive skin that reacts easily to external stimuli and frequently turns red.",
     },
     {
         "id": "combination",
@@ -61,7 +61,7 @@ SKIN_TYPES = [
         "moisture_level": Level.mid,
         "oil_level": Level.mid,
         "sensitivity": Level.low,
-        "description": "T존은 지성, 볼은 건성인 복합성 피부",
+        "description": "Combination skin: oily T-zone and dry cheeks.",
     },
 ]
 
@@ -133,7 +133,7 @@ def seed_skin_types(db):
             db.add(SkinProfile(id=str(uuid.uuid4()), **profile_data))
 
     db.commit()
-    print(f"{len(SKIN_TYPES)}개 피부 타입, {len(SKIN_PROFILES)}개 profile 저장 완료!")
+    print(f"Saved {len(SKIN_TYPES)} skin types and {len(SKIN_PROFILES)} profiles.")
 
 
 def seed():
@@ -146,7 +146,7 @@ def seed():
     with open("data/beauty.csv", encoding="utf-8", errors="ignore") as f:
         reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
-            if count >= 500:  # 일단 500개만
+            if count >= 500:  # limit to 500 for now
                 break
 
             name = row.get("product_name", "").strip()
@@ -174,7 +174,7 @@ def seed():
 
     db.commit()
     db.close()
-    print(f"{count}개 제품 저장 완료!")
+    print(f"Saved {count} products.")
 
 if __name__ == "__main__":
     seed()

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -98,7 +98,7 @@ class Product(Base):
     name = Column(String, nullable=False)
     brand = Column(String)
     category = Column(String)
-    ingredients = Column(JSON)                  # 성분 리스트
-    avoid_conditions = Column(JSON)             # 회피 피부 컨디션
+    ingredients = Column(JSON)                  # ingredient list
+    avoid_conditions = Column(JSON)             # skin conditions to avoid
     image_url = Column(String)
-    suitable_skin_types = Column(JSON)          # 적합 피부 타입 ID 리스트
+    suitable_skin_types = Column(JSON)          # suitable skin type ID list

--- a/backend/pipeline/face.py
+++ b/backend/pipeline/face.py
@@ -5,7 +5,7 @@ import numpy as np
 
 MODEL_PATH = "models/face_landmarker.task"
 
-# 랜드마크 인덱스 (MediaPipe 468개 중 주요 부위)
+# Landmark indices (key regions among MediaPipe's 468 landmarks)
 ROI_INDICES = {
     "forehead": [10, 67, 69, 104, 108, 151, 299, 337, 338],
     "left_cheek": [116, 117, 118, 119, 120, 121, 126, 142, 203],
@@ -25,24 +25,24 @@ def load_landmarker():
 def extract_landmarks(image_path: str) -> dict:
     landmarker = load_landmarker()
 
-    # 이미지 로드
+    # Load image
     mp_image = mp.Image.create_from_file(image_path)
     result = landmarker.detect(mp_image)
 
-    # 얼굴 미감지 처리
+    # Handle no face detected
     if not result.face_landmarks:
-        raise ValueError("얼굴을 감지할 수 없습니다.")
+        raise ValueError("No face detected in the image.")
 
     landmarks = result.face_landmarks[0]
     h, w = mp_image.height, mp_image.width
 
-    # 픽셀 좌표로 변환
+    # Convert to pixel coordinates
     points = [
         (int(lm.x * w), int(lm.y * h))
         for lm in landmarks
     ]
 
-    # 바운딩박스 추출
+    # Extract bounding box
     xs = [p[0] for p in points]
     ys = [p[1] for p in points]
     bbox = {
@@ -52,7 +52,7 @@ def extract_landmarks(image_path: str) -> dict:
         "y_max": max(ys),
     }
 
-    # ROI 좌표 추출
+    # Extract ROI coordinates
     roi_points = {
         region: [points[i] for i in indices]
         for region, indices in ROI_INDICES.items()

--- a/backend/pipeline/face_shape.py
+++ b/backend/pipeline/face_shape.py
@@ -7,8 +7,8 @@ def _dist(a, b) -> float:
 
 def classify_face_shape(landmarks: list) -> str:
     """
-    MediaPipe 468개 랜드마크로 얼굴형 분류.
-    반환값: "oval" | "round" | "square" | "heart" | "long"
+    Classify face shape from MediaPipe 468 landmarks.
+    Returns: "oval" | "round" | "square" | "heart" | "long"
     """
     if len(landmarks) < 468:
         return "oval"

--- a/backend/pipeline/gemini.py
+++ b/backend/pipeline/gemini.py
@@ -1,18 +1,48 @@
+import logging
+from google import genai
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_SKIN_TYPE_EN = {"dry": "Dry", "oily": "Oily", "sensitive": "Sensitive", "combination": "Combination"}
+_LIGHTING_EN = {"bright": "Bright Indoor", "dark": "Dark Environment", "outdoor": "Outdoor"}
+
+
+def _get_client():
+    return genai.Client(api_key=settings.gemini_api_key)
+
+
 def generate_recommendation_reason(skin_type: str, scores: dict, products: list) -> str:
-    
-    skin_type_kr = {
-        "dry": "건성",
-        "oily": "지성",
-        "sensitive": "민감성",
-        "combination": "복합성"
-    }
-    
+    skin_type_en = _SKIN_TYPE_EN.get(skin_type, skin_type)
     redness_label = scores["redness"]["label"]
     moisture_label = scores["moisture"]["label"]
     trouble_label = scores["trouble"]["label"]
-    
-    reason = f"현재 피부는 {skin_type_kr.get(skin_type, skin_type)} 타입으로 분석되었습니다. "
-    reason += f"붉은기는 '{redness_label}', 수분은 '{moisture_label}', 트러블은 '{trouble_label}' 상태입니다. "
-    reason += "이에 맞는 성분이 포함된 제품들을 추천해드립니다."
-    
+
+    reason = f"Your skin has been analyzed as {skin_type_en} type. "
+    reason += f"Redness: '{redness_label}', Moisture: '{moisture_label}', Trouble: '{trouble_label}'. "
+    reason += "We recommend products with ingredients suited to your skin condition."
     return reason
+
+
+def generate_makeup_reason(skin_type: str, lighting_env: str, palette: dict) -> str:
+    skin_en = _SKIN_TYPE_EN.get(skin_type, skin_type)
+    light_en = _LIGHTING_EN.get(lighting_env, lighting_env)
+
+    prompt = (
+        f"Skin type: {skin_en}, Lighting environment: {light_en}\n"
+        f"Recommended foundation color: {palette['foundation']}, blush: {palette['blush']}, "
+        f"lip color: {palette['lip']}, eye shadow: {palette['eye']}\n\n"
+        "Based on the above, explain in 2-3 natural and friendly English sentences why this makeup palette "
+        "suits the user well. Do not mention the hex color values."
+    )
+
+    try:
+        client = _get_client()
+        response = client.models.generate_content(model="gemini-2.0-flash", contents=prompt)
+        return response.text.strip()
+    except Exception as e:
+        logger.warning("Gemini makeup reason fallback: %s", e)
+        skin_en = _SKIN_TYPE_EN.get(skin_type, skin_type)
+        light_en = _LIGHTING_EN.get(lighting_env, lighting_env)
+        tip = palette.get("tip", "")
+        return f"This palette is optimized for {skin_en} skin type in a {light_en} environment. {tip}"

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -2,35 +2,35 @@ import cv2
 import numpy as np
 
 def preprocess_roi(image_path: str, roi_points: dict) -> dict:
-    # 1. 이미지 로드
+    # 1. Load image
     image = cv2.imread(image_path)
     
     result = {}
-    
+
     for region, points in roi_points.items():
-        # 2. 마스크 생성 (검정 배경)
+        # 2. Create mask (black background)
         mask = np.zeros(image.shape[:2], dtype=np.uint8)
-        
-        # 3. ROI 영역 흰색으로 채우기
+
+        # 3. Fill ROI region with white
         pts = np.array(points, dtype=np.int32)
         cv2.fillPoly(mask, [pts], 255)
-        
-        # 4. 마스크 적용 → 해당 부위만 남김
+
+        # 4. Apply mask — keep only the region of interest
         roi = cv2.bitwise_and(image, image, mask=mask)
-        
-        # 5. BGR → LAB 변환
+
+        # 5. BGR → LAB conversion
         lab = cv2.cvtColor(roi, cv2.COLOR_BGR2LAB)
-        
-        # 6. BGR → HSV 변환
+
+        # 6. BGR → HSV conversion
         hsv = cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
-        
-        # 7. CLAHE 조명 보정 (LAB의 L채널에 적용)
+
+        # 7. CLAHE lighting correction (applied to L channel of LAB)
         clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
         l, a, b = cv2.split(lab)
         l_corrected = clahe.apply(l)
         lab_corrected = cv2.merge([l_corrected, a, b])
-        
-        # 8. 노이즈 제거
+
+        # 8. Noise reduction
         denoised = cv2.GaussianBlur(lab_corrected, (5, 5), 0)
         
         result[region] = {

--- a/backend/pipeline/scoring.py
+++ b/backend/pipeline/scoring.py
@@ -11,7 +11,7 @@ def calculate_scores(preprocessed: dict) -> dict:
         lab = data["lab"]
         mask = data["mask"]
 
-        # 마스크 적용된 픽셀만 추출
+        # Extract only masked pixels
         masked_pixels = lab[mask == 255]
         if len(masked_pixels) == 0:
             continue
@@ -19,37 +19,37 @@ def calculate_scores(preprocessed: dict) -> dict:
         l_channel = masked_pixels[:, 0].astype(float)
         a_channel = masked_pixels[:, 1].astype(float)
 
-        # 붉은기 — a채널 평균 (128 기준, 높을수록 붉음)
+        # Redness — a-channel mean (baseline 128, higher = more red)
         redness = float(np.mean(a_channel))
         redness_scores.append(redness)
 
-        # 밝기 — L채널 평균
+        # Brightness — L-channel mean
         brightness = float(np.mean(l_channel))
         brightness_scores.append(brightness)
 
-        # 톤 불균형 — L채널 분산
+        # Tone imbalance — L-channel variance
         tone_var = float(np.var(l_channel))
         tone_scores.append(tone_var)
 
-        # 트러블 — a채널에서 이상 픽셀 비율
+        # Trouble — proportion of abnormal pixels in a-channel
         trouble_pixels = np.sum(a_channel > 140)
         trouble_ratio = float(trouble_pixels / len(masked_pixels))
         trouble_scores.append(trouble_ratio)
 
-    # 평균값 계산
+    # Compute averages
     avg_redness = np.mean(redness_scores) if redness_scores else 128
     avg_brightness = np.mean(brightness_scores) if brightness_scores else 128
     avg_tone = np.mean(tone_scores) if tone_scores else 0
     avg_trouble = np.mean(trouble_scores) if trouble_scores else 0
 
-    # 0~100 정규화
+    # Normalize to 0~100
     redness_score = float(np.clip((avg_redness - 128) / 20 * 100, 0, 100))
     brightness_score = float(np.clip(avg_brightness / 255 * 100, 0, 100))
     tone_score = float(np.clip(100 - (avg_tone / 500 * 100), 0, 100))
     trouble_score = float(np.clip(avg_trouble * 100 * 3, 0, 100))
     moisture_score = float(np.clip((brightness_score + (100 - redness_score)) / 2, 0, 100))
 
-    # 차트용 점수 (높을수록 좋음으로 정규화)
+    # Chart scores (normalized so higher = better)
     def get_status(score, reverse=False):
         s = 100 - score if reverse else score
         if s >= 60:
@@ -61,11 +61,11 @@ def calculate_scores(preprocessed: dict) -> dict:
 
     def get_label(metric, status):
         labels = {
-            "redness":    {"good": "진정됨", "caution": "약간 붉음", "bad": "붉음"},
-            "tone":       {"good": "균일", "caution": "약간 불균일", "bad": "불균일"},
-            "brightness": {"good": "밝음", "caution": "보통", "bad": "칙칙함"},
-            "trouble":    {"good": "깨끗", "caution": "약간 있음", "bad": "트러블"},
-            "moisture":   {"good": "촉촉", "caution": "보통", "bad": "건조"},
+            "redness":    {"good": "Calm", "caution": "Slightly red", "bad": "Red"},
+            "tone":       {"good": "Even", "caution": "Slightly uneven", "bad": "Uneven"},
+            "brightness": {"good": "Bright", "caution": "Moderate", "bad": "Dull"},
+            "trouble":    {"good": "Clear", "caution": "Slight trouble", "bad": "Trouble"},
+            "moisture":   {"good": "Hydrated", "caution": "Moderate", "bad": "Dry"},
         }
         return labels[metric][status]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,5 +12,5 @@ sqlalchemy
 alembic
 python-jose[cryptography]
 httpx
-google-generativeai
+google-genai
 

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -27,7 +27,7 @@ def get_history(
 ):
     from fastapi import HTTPException
     if not current_user:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+        raise HTTPException(status_code=401, detail="Login required.")
 
     from sqlalchemy import desc
     records = (
@@ -60,11 +60,11 @@ async def analyze_skin(
 ):
 
     if file.content_type not in ALLOWED_TYPES:
-        raise HTTPException(status_code=400, detail="지원하지 않는 파일 형식입니다.")
-    
+        raise HTTPException(status_code=400, detail="Unsupported file type.")
+
     contents = await file.read()
     if len(contents) > MAX_SIZE:
-        raise HTTPException(status_code=400, detail="파일 크기는 10MB 이하여야 합니다.")
+        raise HTTPException(status_code=400, detail="File size must be 10MB or less.")
 
     record_id = str(uuid.uuid4())
     suffix = os.path.splitext(file.filename)[1]
@@ -76,20 +76,20 @@ async def analyze_skin(
         f.write(contents)
 
     try:
-        # 1. 랜드마크 추출
+        # 1. Extract landmarks
         landmarks = extract_landmarks(tmp_path)
-        
-        # 2. ROI 전처리
+
+        # 2. ROI preprocessing
         preprocessed = preprocess_roi(tmp_path, landmarks["roi_points"])
-        
-        # 3. 피부 점수화
+
+        # 3. Skin scoring
         scores = calculate_scores(preprocessed)
-        
-        # 4. 피부 타입 분류
+
+        # 4. Skin type classification
         from routers.recommend import classify_skin_type, RECOMMENDED_INGREDIENTS
         skin_type = classify_skin_type(scores)
-        
-        # 5. 제품 추천
+
+        # 5. Product recommendation
         avoid_conditions = [
             k for k, v in scores.items()
             if isinstance(v, dict) and v.get("status") == "bad"
@@ -99,10 +99,11 @@ async def analyze_skin(
         products = db.query(Product).all()
         scored_products = []
         for product in products:
-            # 카테고리 필터 추가
+            # Category filter
             category = (product.category or "").lower()
             if not any(c in category for c in ["skincare", "moisturizer", "serum", "toner", "sunscreen", "foundation", "bb cream", "face", "skin"]):
                 continue
+
 
             ingredients = product.ingredients or []
             avoid = product.avoid_conditions or []
@@ -134,7 +135,7 @@ async def analyze_skin(
         unique_products.sort(key=lambda x: x["match_score"], reverse=True)
         top_products = unique_products[:5]
         
-        # 6. Gemini 추천 이유 생성
+        # 6. Generate Gemini recommendation reason
         reason = generate_recommendation_reason(skin_type, scores, top_products)
         for p in top_products:
             p["reason"] = reason

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -6,17 +6,22 @@ from db.session import get_db
 from db.models import Product
 from schemas.skin import SkinScores
 from pipeline.face_shape import classify_face_shape
+from pipeline.gemini import generate_makeup_reason
 
 HAIRSTYLES_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "hairstyles.json")
 with open(HAIRSTYLES_PATH, encoding="utf-8") as f:
     HAIRSTYLES_DATA = json.load(f)
+
+MAKEUP_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "makeup_palettes.json")
+with open(MAKEUP_PATH, encoding="utf-8") as f:
+    MAKEUP_DATA = json.load(f)
 
 router = APIRouter()
 
 ALLOWED_CATEGORIES = ["skincare", "moisturizer", "serum", "toner", "sunscreen", "foundation", "bb cream", "face", "skin"]
 
 
-# 피부 타입 분류
+# Skin type classification
 def classify_skin_type(scores: dict) -> str:
     moisture = scores["moisture"]["score"]
     redness = scores["redness"]["score"]
@@ -31,7 +36,7 @@ def classify_skin_type(scores: dict) -> str:
     else:
         return "combination"
 
-# 피부 타입별 추천 성분
+# Recommended ingredients by skin type
 RECOMMENDED_INGREDIENTS = {
     "dry":         ["hyaluronic acid", "glycerin", "ceramide", "squalane"],
     "oily":        ["niacinamide", "salicylic acid", "zinc", "tea tree"],
@@ -44,19 +49,19 @@ def recommend_products(scores: dict, db: Session = Depends(get_db)):
     skin_type = classify_skin_type(scores)
     recommended = RECOMMENDED_INGREDIENTS[skin_type]
 
-    # 부적합 상태 기반 회피 조건
+    # Avoid conditions based on bad-status metrics
     avoid_conditions = [
         k for k, v in scores.items()
         if isinstance(v, dict) and v.get("status") == "bad"
     ]
 
-    # DB에서 제품 필터링
+    # Filter products from DB
     products = db.query(Product).all()
-    
+
     scored_products = []
     for product in products:
 
-        # 카테고리 필터
+        # Category filter
         category = (product.category or "").lower()
         if not any(c in category for c in ALLOWED_CATEGORIES):
             continue
@@ -64,11 +69,11 @@ def recommend_products(scores: dict, db: Session = Depends(get_db)):
         ingredients = product.ingredients or []
         avoid = product.avoid_conditions or []
 
-        # 회피 조건 겹치면 제외
+        # Exclude if avoid conditions overlap
         if any(c in avoid for c in avoid_conditions):
             continue
 
-        # 추천 성분 매칭 점수
+        # Recommended ingredient match score
         match_count = sum(
             1 for rec in recommended
             if any(rec in ing for ing in ingredients)
@@ -86,8 +91,7 @@ def recommend_products(scores: dict, db: Session = Depends(get_db)):
                 "image_url": product.image_url,
             })
 
-    # 매칭 점수 높은 순으로 상위 5개
-    # 이름 기준 중복 제거
+    # Top 5 by match score, deduplicated by name
     seen_names = set()
     unique_products = []
     for p in scored_products:
@@ -109,7 +113,50 @@ def recommend_hairstyle(body: dict):
     data = HAIRSTYLES_DATA.get(face_shape, HAIRSTYLES_DATA["oval"])
     return {
         "face_shape": face_shape,
-        "face_shape_ko": data["label_ko"],
-        "description": data["description_ko"],
+        "face_shape_label": data["label"],
+        "description": data["description"],
         "styles": data["styles"],
+    }
+
+
+MAKEUP_CATEGORIES = ["foundation", "bb cream", "concealer", "blush", "cheek",
+                     "lipstick", "lip", "eyeshadow", "eye", "makeup", "colour", "color"]
+
+@router.post("/makeup")
+def recommend_makeup(body: dict, db: Session = Depends(get_db)):
+    skin_type = body.get("skin_type", "combination")
+    lighting_env = body.get("lighting_env", "bright")
+
+    lighting_data = MAKEUP_DATA.get(lighting_env, MAKEUP_DATA["bright"])
+    palette = lighting_data.get(skin_type, lighting_data["combination"])
+
+    # Fetch makeup-category products
+    products = db.query(Product).all()
+    makeup_products = []
+    for p in products:
+        category = (p.category or "").lower()
+        if not any(c in category for c in MAKEUP_CATEGORIES):
+            continue
+        makeup_products.append({
+            "id": p.id,
+            "name": p.name,
+            "brand": p.brand,
+            "category": p.category,
+            "image_url": p.image_url,
+        })
+
+    palette_colors = {
+        "foundation": palette["foundation"],
+        "blush": palette["blush"],
+        "lip": palette["lip"],
+        "eye": palette["eye"],
+    }
+    reason = generate_makeup_reason(skin_type, lighting_env, palette)
+
+    return {
+        "skin_type": skin_type,
+        "lighting_env": lighting_env,
+        "palette": palette_colors,
+        "tip": reason,
+        "products": makeup_products[:6],
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - "3000:3000"
     command: sh -c "npm install && npm run dev"
+    restart: unless-stopped
 
   db:
     image: postgres:16

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -36,15 +36,15 @@ function formatDateLong(iso: string) {
 
 function getSkinTypeSummary(skin_type: string, overall_score: number): string {
   const typeMap: Record<string, string> = {
-    dry: "건조한 피부 상태입니다. 보습 관리에 신경써주세요.",
-    oily: "피지 분비가 활발합니다. 유분 조절이 필요합니다.",
-    sensitive: "피부 자극에 주의가 필요합니다. 진정 케어를 추천합니다.",
-    combination: "복합성 피부입니다. 부위별 맞춤 케어가 효과적입니다.",
+    dry: "Skin is dry. Focus on moisture management.",
+    oily: "Sebum production is high. Oil control is recommended.",
+    sensitive: "Skin is prone to irritation. Calming care is recommended.",
+    combination: "Combination skin. Zone-specific care is most effective.",
   }
-  const base = typeMap[skin_type] ?? "피부 분석이 완료되었습니다."
-  if (overall_score >= 75) return `컨디션이 좋습니다. ${base}`
-  if (overall_score >= 50) return `보통 컨디션입니다. ${base}`
-  return `관리가 필요한 상태입니다. ${base}`
+  const base = typeMap[skin_type] ?? "Skin analysis complete."
+  if (overall_score >= 75) return `Skin condition is good. ${base}`
+  if (overall_score >= 50) return `Skin condition is average. ${base}`
+  return `Skin needs attention. ${base}`
 }
 
 export default function HistoryPage() {
@@ -59,7 +59,7 @@ export default function HistoryPage() {
     getHistory()
       .then(setHistory)
       .catch((e: Error) => {
-        if (e.message.includes("로그인")) setIsLoggedOut(true)
+        if (e.message.includes("Login")) setIsLoggedOut(true)
       })
       .finally(() => setLoading(false))
   }, [])
@@ -73,7 +73,7 @@ export default function HistoryPage() {
     else setCurrentMonth(m => m + 1)
   }
 
-  // 현재 뷰 월의 분석 날짜 목록
+  // Analysis dates in current viewed month
   const daysWithAnalysis = history
     .filter(r => {
       const d = new Date(r.analyzed_at)
@@ -85,7 +85,7 @@ export default function HistoryPage() {
   const days = Array.from({ length: daysInMonth }, (_, i) => i + 1)
   const today = new Date()
 
-  // 차트용: 최신 10개, 날짜 오름차순
+  // Chart data: latest 10, ascending by date
   const chartData = [...history]
     .slice(0, 10)
     .reverse()
@@ -114,17 +114,17 @@ export default function HistoryPage() {
             <Calendar className="w-12 h-12 text-[#F9A8C9]" />
           </div>
           <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
-            {isLoggedOut ? "로그인이 필요합니다" : "No History Yet"}
+            {isLoggedOut ? "Login required" : "No History Yet"}
           </h2>
           <p className="text-muted-foreground text-center mb-8 max-w-xs">
             {isLoggedOut
-              ? "히스토리를 보려면 로그인 후 분석을 진행해주세요."
+              ? "Please log in and complete an analysis to view your history."
               : "Start your first skin analysis to begin tracking your skin journey over time."}
           </p>
           <Link href="/upload">
             <Button className="bg-[#F9A8C9] hover:bg-[#F9A8C9]/90 text-white rounded-full px-8 py-6 text-base font-medium">
               <Camera className="w-5 h-5 mr-2" />
-              {isLoggedOut ? "분석 시작하기" : "Start First Analysis"}
+              {isLoggedOut ? "Start Analysis" : "Start First Analysis"}
             </Button>
           </Link>
         </main>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -37,7 +37,7 @@ export default function ProfilePage() {
         </header>
 
         <main className="px-4 py-8 space-y-6">
-          {/* profile 카드 */}
+          {/* Profile card */}
           <div className="flex flex-col items-center gap-4 rounded-2xl border border-border/50 bg-white p-8 shadow-sm">
             <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#FDF2F8]">
               {user.picture ? (
@@ -59,7 +59,7 @@ export default function ProfilePage() {
             </div>
           </div>
 
-          {/* logout 버튼 */}
+          {/* Logout button */}
           <Button
             variant="outline"
             className="w-full rounded-xl py-6 text-sm font-medium text-muted-foreground"

--- a/frontend/src/app/result/page.tsx
+++ b/frontend/src/app/result/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { AnalyzeResponse } from "@/types/api"
-import { ChevronLeft, Calendar, Bookmark, LogIn, TrendingUp } from "lucide-react"
+import { ChevronLeft, Calendar, Bookmark, LogIn, TrendingUp, Palette, ChevronRight } from "lucide-react"
 import Link from "next/link"
 import { useAuth } from "@/hooks/useAuth"
 import {
@@ -149,7 +149,7 @@ export default function ResultsPage() {
     { label: "Moisture", score: analysisData.skin_scores.moisture.score, color: "#93C5FD" },
   ] : []
 
-  // recommendedProducts 부분 교체
+  // Build recommended products list
   const recommendedProducts = analysisData?.products.map(p => ({
     id: p.id,
     name: p.name,
@@ -210,7 +210,7 @@ export default function ResultsPage() {
   <CardContent className="p-0">
     <div className="relative aspect-4/5 w-full bg-linear-to-br from-[#FDF2F8] to-[#F3E8FF] lg:aspect-3/4">
       
-      {/* 업로드 이미지 */}
+      {/* Uploaded image */}
       {uploadedImage ? (
         <img
           src={uploadedImage}
@@ -225,15 +225,15 @@ export default function ResultsPage() {
         </div>
       )}
 
-      {/* SVG 오버레이 */}
+      {/* SVG overlay */}
       {uploadedImage && analysisData?.landmarks && analysisData.landmarks.length > 0 && (
         <svg
           className="absolute inset-0 w-full h-full"
           viewBox={`0 0 ${analysisData.image_size.width} ${analysisData.image_size.height}`}
           preserveAspectRatio="xMidYMid slice"
         >
-          {/* ROI 영역별 반투명 색칠 */}
-          {/* 이마 영역 */}
+          {/* ROI region semi-transparent overlay */}
+          {/* Forehead region */}
           <polygon
             points={analysisData.landmarks ?
               [251,284,332,297,338,10,109,67,54,21,162,127,234,93,132,58,172,136,150,149,176,148,152,377,378,365,397,288,361,323,454,356,389].map(i =>
@@ -245,7 +245,7 @@ export default function ResultsPage() {
             strokeWidth="1"
             strokeOpacity="0.5"
           />
-          {/* 왼볼 */}
+          {/* Left cheek */}
           <polygon
             points={analysisData.landmarks ?
               [116,117,118,119,120,121,126,142,203].map(i =>
@@ -257,7 +257,7 @@ export default function ResultsPage() {
             strokeWidth="1"
             strokeOpacity="0.5"
           />
-          {/* 오른볼 */}
+          {/* Right cheek */}
           <polygon
             points={analysisData.landmarks ?
               [345,346,347,348,349,350,355,371,423].map(i =>
@@ -270,19 +270,19 @@ export default function ResultsPage() {
             strokeOpacity="0.5"
           />
           {[
-            // 코 중심
+            // Nose center
             1, 4, 5, 6, 195, 197, 168, 9, 8,
-            // 눈 주변
+            // Around eyes
             33, 133, 362, 263, 159, 145, 386, 374,
-            // 눈썹
+            // Eyebrows
             55, 285, 52, 282, 65, 295,
-            // 입 주변
+            // Around mouth
             61, 291, 17, 18, 200, 13, 14, 78, 308,
-            // 코 옆
+            // Nose sides
             48, 278, 219, 439,
-            // 이마
+            // Forehead
             151, 10, 338,
-            // 턱
+            // Chin
             152, 175, 176, 177, 178,
           ].map(i =>
             analysisData.landmarks[i] ? (
@@ -406,6 +406,24 @@ export default function ResultsPage() {
                   ))}
                 </div>
               </section>
+
+              {/* Makeup preview */}
+              {analysisData?.skin_type && (
+                <Link href="/style/makeup">
+                  <Card className="p-4 rounded-2xl border-border/50 shadow-sm bg-linear-to-br from-white to-[#F9A8C9]/5 hover:shadow-md transition-shadow">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-xl bg-[#F9A8C9]/15 flex items-center justify-center shrink-0">
+                        <Palette className="w-5 h-5 text-[#F9A8C9]" />
+                      </div>
+                      <div className="flex-1">
+                        <p className="font-medium text-foreground text-sm">Get Makeup Recommendation</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">Check the color palette matched to your lighting</p>
+                      </div>
+                      <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
+                    </div>
+                  </Card>
+                </Link>
+              )}
 
               {/* Save button - mobile only */}
               <Button

--- a/frontend/src/app/style/hairstyle/page.tsx
+++ b/frontend/src/app/style/hairstyle/page.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Scissors, Camera, ChevronRight } from "lucide-react"
+import { BottomNav } from "@/components/bottom-nav"
+import { DesktopSidebar } from "@/components/desktop-sidebar"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import Link from "next/link"
+import { getHistory, getHairstyleRecommendation } from "@/lib/api"
+
+interface HairstyleResult {
+  face_shape: string
+  face_shape_label: string
+  description: string
+  styles: {
+    name: string
+    reason: string
+    length: string
+    tags: string[]
+  }[]
+}
+
+const FACE_SHAPE_EMOJI: Record<string, string> = {
+  oval: "🥚",
+  round: "⭕",
+  square: "⬛",
+  heart: "🫀",
+  long: "📏",
+}
+
+const LENGTH_LABEL: Record<string, string> = {
+  short: "Short",
+  medium: "Medium",
+  long: "Long",
+}
+
+export default function StylePage() {
+  const [result, setResult] = useState<HairstyleResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<"no_history" | "no_login" | null>(null)
+
+  useEffect(() => {
+    getHistory()
+      .then((history) => {
+        if (history.length === 0) {
+          setError("no_history")
+          return
+        }
+        const latest = history[0]
+        if (!latest.landmarks || latest.landmarks.length === 0) {
+          setError("no_history")
+          return
+        }
+        return getHairstyleRecommendation(latest.landmarks)
+      })
+      .then((data) => {
+        if (data) setResult(data)
+      })
+      .catch((e: Error) => {
+        if (e.message.includes("Login")) setError("no_login")
+        else setError("no_history")
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col items-center justify-center">
+        <div className="w-8 h-8 rounded-full border-2 border-[#C4B5FD] border-t-transparent animate-spin" />
+        <p className="text-sm text-muted-foreground mt-3">Analyzing face shape...</p>
+      </div>
+    </div>
+  )
+
+  if (error) return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4">
+            <h1 className="text-xl font-semibold text-foreground">Style Consultant</h1>
+          </div>
+        </header>
+        <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
+          <div className="w-24 h-24 rounded-full bg-[#C4B5FD]/10 flex items-center justify-center mb-6">
+            <Scissors className="w-12 h-12 text-[#C4B5FD]" />
+          </div>
+          <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
+            {error === "no_login" ? "Login required" : "No analysis history"}
+          </h2>
+          <p className="text-muted-foreground text-center mb-8 max-w-xs">
+            {error === "no_login"
+              ? "Log in and run a skin analysis to get face-shape-based hairstyle recommendations."
+              : "Please complete a skin analysis first. We will detect your face shape and suggest suitable hairstyles."}
+          </p>
+          <Link href="/upload">
+            <Button className="bg-[#C4B5FD] hover:bg-[#C4B5FD]/90 text-white rounded-full px-8 py-6 text-base font-medium">
+              <Camera className="w-5 h-5 mr-2" />
+              Start Analysis
+            </Button>
+          </Link>
+        </main>
+        <BottomNav activeTab="style" />
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col pb-24">
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4 flex items-center gap-3">
+            <h1 className="text-xl font-semibold text-foreground">Style Consultant</h1>
+          </div>
+        </header>
+
+        <main className="px-4 py-6 space-y-6">
+          {/* Face shape result card */}
+          <Card className="p-5 rounded-2xl border-border/50 shadow-sm bg-linear-to-br from-white to-[#C4B5FD]/5">
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-2xl bg-[#C4B5FD]/15 flex items-center justify-center text-3xl shrink-0">
+                {FACE_SHAPE_EMOJI[result!.face_shape] ?? "✨"}
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground mb-1">My Face Shape</p>
+                <h2 className="text-2xl font-bold text-foreground">{result!.face_shape_label}</h2>
+                <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+                  {result!.description}
+                </p>
+              </div>
+            </div>
+          </Card>
+
+          {/* Recommended hairstyle list */}
+          <div>
+            <h2 className="font-semibold text-foreground mb-3">Recommended Hairstyles</h2>
+            <div className="space-y-3">
+              {result!.styles.map((style, i) => (
+                <Card key={i} className="p-4 rounded-2xl border-border/50 shadow-sm">
+                  <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 rounded-xl bg-[#C4B5FD]/15 flex items-center justify-center shrink-0">
+                      <Scissors className="w-5 h-5 text-[#C4B5FD]" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="font-semibold text-foreground">{style.name}</span>
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-[#C4B5FD]/10 text-[#8B7DCF]">
+                          {LENGTH_LABEL[style.length] ?? style.length}
+                        </span>
+                      </div>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {style.reason}
+                      </p>
+                      <div className="flex flex-wrap gap-1.5 mt-2">
+                        {style.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground"
+                          >
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </div>
+
+          {/* Re-analyze */}
+          <Link href="/upload">
+            <Button
+              variant="outline"
+              className="w-full py-6 rounded-full border-[#C4B5FD] text-[#8B7DCF] hover:bg-[#C4B5FD]/10 font-medium text-base"
+            >
+              <Camera className="w-5 h-5 mr-2" />
+              New Analysis
+              <ChevronRight className="w-4 h-4 ml-auto" />
+            </Button>
+          </Link>
+        </main>
+
+        <BottomNav activeTab="style" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/style/makeup/page.tsx
+++ b/frontend/src/app/style/makeup/page.tsx
@@ -1,0 +1,205 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Palette, Camera, ChevronLeft } from "lucide-react"
+import { BottomNav } from "@/components/bottom-nav"
+import { DesktopSidebar } from "@/components/desktop-sidebar"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import Link from "next/link"
+import { getHistory, getMakeupRecommendation } from "@/lib/api"
+
+interface MakeupProduct {
+  id: string
+  name: string
+  brand: string
+  category: string
+  image_url: string | null
+}
+
+interface MakeupResult {
+  skin_type: string
+  lighting_env: string
+  palette: { foundation: string; blush: string; lip: string; eye: string }
+  tip: string
+  products: MakeupProduct[]
+}
+
+const LIGHTING_OPTIONS = [
+  { key: "bright", label: "Bright Indoor", emoji: "💡" },
+  { key: "dark",   label: "Dark Environment", emoji: "🌙" },
+  { key: "outdoor", label: "Outdoor", emoji: "☀️" },
+]
+
+const PALETTE_LABELS: Record<keyof MakeupResult["palette"], string> = {
+  foundation: "Foundation",
+  blush: "Blush",
+  lip: "Lip",
+  eye: "Eye Shadow",
+}
+
+export default function MakeupPage() {
+  const [skinType, setSkinType] = useState<string | null>(null)
+  const [lighting, setLighting] = useState("bright")
+  const [result, setResult] = useState<MakeupResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [initError, setInitError] = useState<"no_login" | "no_history" | null>(null)
+  const [initLoading, setInitLoading] = useState(true)
+
+  useEffect(() => {
+    getHistory()
+      .then((history) => {
+        if (history.length === 0) { setInitError("no_history"); return }
+        setSkinType(history[0].skin_type)
+      })
+      .catch((e: Error) => {
+        setInitError(e.message.includes("Login") ? "no_login" : "no_history")
+      })
+      .finally(() => setInitLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (!skinType) return
+    setLoading(true)
+    getMakeupRecommendation(skinType, lighting)
+      .then(setResult)
+      .finally(() => setLoading(false))
+  }, [skinType, lighting])
+
+  if (initLoading) return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 items-center justify-center">
+        <div className="w-8 h-8 rounded-full border-2 border-[#F9A8C9] border-t-transparent animate-spin" />
+      </div>
+    </div>
+  )
+
+  if (initError) return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4 flex items-center gap-3">
+            <Link href="/style"><ChevronLeft className="w-5 h-5 text-muted-foreground" /></Link>
+            <h1 className="text-xl font-semibold text-foreground">Makeup Recommendation</h1>
+          </div>
+        </header>
+        <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
+          <div className="w-24 h-24 rounded-full bg-[#F9A8C9]/10 flex items-center justify-center mb-6">
+            <Palette className="w-12 h-12 text-[#F9A8C9]" />
+          </div>
+          <h2 className="text-xl font-semibold mb-2">
+            {initError === "no_login" ? "Login required" : "No analysis history"}
+          </h2>
+          <p className="text-muted-foreground text-center mb-8 max-w-xs">
+            After skin analysis, you can get a makeup palette matched to your lighting environment.
+          </p>
+          <Link href="/upload">
+            <Button className="bg-[#F9A8C9] hover:bg-[#F9A8C9]/90 text-white rounded-full px-8 py-6">
+              <Camera className="w-5 h-5 mr-2" />Start Analysis
+            </Button>
+          </Link>
+        </main>
+        <BottomNav activeTab="style" />
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <DesktopSidebar />
+      <div className="flex min-w-0 flex-1 flex-col pb-24">
+        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
+          <div className="px-4 py-4 flex items-center gap-3">
+            <Link href="/style"><ChevronLeft className="w-5 h-5 text-muted-foreground" /></Link>
+            <h1 className="text-xl font-semibold text-foreground">Makeup Recommendation</h1>
+          </div>
+        </header>
+
+        <main className="px-4 py-6 space-y-6">
+          {/* Lighting toggle */}
+          <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
+            <p className="text-sm font-medium text-foreground mb-3">Today's Lighting Environment</p>
+            <div className="flex gap-2">
+              {LIGHTING_OPTIONS.map((opt) => (
+                <button
+                  key={opt.key}
+                  onClick={() => setLighting(opt.key)}
+                  className={`flex-1 flex flex-col items-center gap-1 py-3 rounded-xl text-sm font-medium transition-all
+                    ${lighting === opt.key
+                      ? "bg-[#F9A8C9] text-white shadow-sm"
+                      : "bg-muted text-muted-foreground hover:bg-[#F9A8C9]/10"
+                    }`}
+                >
+                  <span className="text-lg">{opt.emoji}</span>
+                  <span className="text-xs">{opt.label}</span>
+                </button>
+              ))}
+            </div>
+          </Card>
+
+          {/* Palette */}
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <div className="w-8 h-8 rounded-full border-2 border-[#F9A8C9] border-t-transparent animate-spin" />
+            </div>
+          ) : result && (
+            <>
+              <Card className="p-4 rounded-2xl border-border/50 shadow-sm">
+                <p className="text-sm font-medium text-foreground mb-4">Recommended Color Palette</p>
+                <div className="grid grid-cols-4 gap-3">
+                  {(Object.entries(result.palette) as [keyof MakeupResult["palette"], string][]).map(([key, hex]) => (
+                    <div key={key} className="flex flex-col items-center gap-2">
+                      <div
+                        className="w-14 h-14 rounded-2xl shadow-sm border border-border/30"
+                        style={{ backgroundColor: hex }}
+                      />
+                      <span className="text-xs text-muted-foreground text-center">
+                        {PALETTE_LABELS[key]}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+
+              {result.tip && (
+                <Card className="p-4 rounded-2xl border-border/50 shadow-sm bg-linear-to-br from-white to-[#F9A8C9]/5">
+                  <p className="text-sm font-medium text-foreground mb-2">Makeup Tip</p>
+                  <p className="text-sm text-muted-foreground leading-relaxed">{result.tip}</p>
+                </Card>
+              )}
+
+              {result.products.length > 0 && (
+                <div>
+                  <p className="text-sm font-medium text-foreground mb-3">Recommended Products</p>
+                  <div className="space-y-3">
+                    {result.products.map((product) => (
+                      <Card key={product.id} className="p-3 rounded-2xl border-border/50 shadow-sm">
+                        <div className="flex items-center gap-3">
+                          <div className="w-14 h-14 rounded-xl bg-muted flex items-center justify-center shrink-0 overflow-hidden">
+                            {product.image_url
+                              ? <img src={product.image_url} alt={product.name} className="w-full h-full object-cover" />
+                              : <Palette className="w-6 h-6 text-muted-foreground" />
+                            }
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-sm text-foreground truncate">{product.name}</p>
+                            <p className="text-xs text-muted-foreground">{product.brand}</p>
+                            <p className="text-xs text-[#F9A8C9] mt-0.5">{product.category}</p>
+                          </div>
+                        </div>
+                      </Card>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </main>
+
+        <BottomNav activeTab="style" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/style/page.tsx
+++ b/frontend/src/app/style/page.tsx
@@ -1,112 +1,31 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Scissors, Camera, ChevronRight } from "lucide-react"
+import { Scissors, Palette, ChevronRight, Sparkles } from "lucide-react"
 import { BottomNav } from "@/components/bottom-nav"
 import { DesktopSidebar } from "@/components/desktop-sidebar"
-import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import Link from "next/link"
-import { getHistory, getHairstyleRecommendation } from "@/lib/api"
 
-interface HairstyleResult {
-  face_shape: string
-  face_shape_ko: string
-  description: string
-  styles: {
-    name_ko: string
-    reason: string
-    length: string
-    tags: string[]
-  }[]
-}
-
-const FACE_SHAPE_EMOJI: Record<string, string> = {
-  oval: "🥚",
-  round: "⭕",
-  square: "⬛",
-  heart: "🫀",
-  long: "📏",
-}
-
-const LENGTH_KO: Record<string, string> = {
-  short: "숏",
-  medium: "미디엄",
-  long: "롱",
-}
+const features = [
+  {
+    href: "/style/hairstyle",
+    icon: Scissors,
+    title: "Hairstyle Recommendation",
+    description: "Analyze your face shape and find hairstyles that suit you best.",
+    color: "#C4B5FD",
+    bg: "from-white to-[#C4B5FD]/5",
+  },
+  {
+    href: "/style/makeup",
+    icon: Palette,
+    title: "Makeup Recommendation",
+    description: "Get a color palette matched to your lighting environment and skin type.",
+    color: "#F9A8C9",
+    bg: "from-white to-[#F9A8C9]/5",
+  },
+]
 
 export default function StylePage() {
-  const [result, setResult] = useState<HairstyleResult | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<"no_history" | "no_login" | null>(null)
-
-  useEffect(() => {
-    getHistory()
-      .then((history) => {
-        if (history.length === 0) {
-          setError("no_history")
-          return
-        }
-        const latest = history[0]
-        if (!latest.landmarks || latest.landmarks.length === 0) {
-          setError("no_history")
-          return
-        }
-        return getHairstyleRecommendation(latest.landmarks)
-      })
-      .then((data) => {
-        if (data) setResult(data)
-      })
-      .catch((e: Error) => {
-        if (e.message.includes("로그인")) setError("no_login")
-        else setError("no_history")
-      })
-      .finally(() => setLoading(false))
-  }, [])
-
-  if (loading) return (
-    <div className="flex min-h-screen bg-background">
-      <DesktopSidebar />
-      <div className="flex min-w-0 flex-1 flex-col items-center justify-center">
-        <div className="w-8 h-8 rounded-full border-2 border-[#C4B5FD] border-t-transparent animate-spin" />
-        <p className="text-sm text-muted-foreground mt-3">얼굴형 분석 중...</p>
-      </div>
-    </div>
-  )
-
-  if (error) return (
-    <div className="flex min-h-screen bg-background">
-      <DesktopSidebar />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <header className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border">
-          <div className="px-4 py-4">
-            <h1 className="text-xl font-semibold text-foreground">Style Consultant</h1>
-          </div>
-        </header>
-        <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
-          <div className="w-24 h-24 rounded-full bg-[#C4B5FD]/10 flex items-center justify-center mb-6">
-            <Scissors className="w-12 h-12 text-[#C4B5FD]" />
-          </div>
-          <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
-            {error === "no_login" ? "로그인이 필요합니다" : "분석 기록이 없어요"}
-          </h2>
-          <p className="text-muted-foreground text-center mb-8 max-w-xs">
-            {error === "no_login"
-              ? "로그인 후 피부 분석을 진행하면 얼굴형 기반 헤어스타일을 추천받을 수 있어요."
-              : "먼저 피부 분석을 진행해주세요. 분석 결과를 바탕으로 얼굴형을 파악하고 헤어스타일을 추천해드려요."}
-          </p>
-          <Link href="/upload">
-            <Button className="bg-[#C4B5FD] hover:bg-[#C4B5FD]/90 text-white rounded-full px-8 py-6 text-base font-medium">
-              <Camera className="w-5 h-5 mr-2" />
-              분석 시작하기
-            </Button>
-          </Link>
-        </main>
-        <BottomNav activeTab="style" />
-      </div>
-    </div>
-  )
-
   return (
     <div className="flex min-h-screen bg-background">
       <DesktopSidebar />
@@ -117,71 +36,33 @@ export default function StylePage() {
           </div>
         </header>
 
-        <main className="px-4 py-6 space-y-6">
-          {/* 얼굴형 결과 카드 */}
-          <Card className="p-5 rounded-2xl border-border/50 shadow-sm bg-linear-to-br from-white to-[#C4B5FD]/5">
-            <div className="flex items-center gap-4">
-              <div className="w-16 h-16 rounded-2xl bg-[#C4B5FD]/15 flex items-center justify-center text-3xl shrink-0">
-                {FACE_SHAPE_EMOJI[result!.face_shape] ?? "✨"}
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground mb-1">내 얼굴형</p>
-                <h2 className="text-2xl font-bold text-foreground">{result!.face_shape_ko}</h2>
-                <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
-                  {result!.description}
-                </p>
-              </div>
-            </div>
-          </Card>
-
-          {/* 추천 헤어스타일 목록 */}
-          <div>
-            <h2 className="font-semibold text-foreground mb-3">추천 헤어스타일</h2>
-            <div className="space-y-3">
-              {result!.styles.map((style, i) => (
-                <Card key={i} className="p-4 rounded-2xl border-border/50 shadow-sm">
-                  <div className="flex items-start gap-3">
-                    <div className="w-10 h-10 rounded-xl bg-[#C4B5FD]/15 flex items-center justify-center shrink-0">
-                      <Scissors className="w-5 h-5 text-[#C4B5FD]" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="font-semibold text-foreground">{style.name_ko}</span>
-                        <span className="text-xs px-2 py-0.5 rounded-full bg-[#C4B5FD]/10 text-[#8B7DCF]">
-                          {LENGTH_KO[style.length] ?? style.length}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground leading-relaxed">
-                        {style.reason}
-                      </p>
-                      <div className="flex flex-wrap gap-1.5 mt-2">
-                        {style.tags.map((tag) => (
-                          <span
-                            key={tag}
-                            className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground"
-                          >
-                            #{tag}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              ))}
-            </div>
+        <main className="px-4 py-6 space-y-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Sparkles className="w-4 h-4 text-[#C4B5FD]" />
+            <p className="text-sm text-muted-foreground">Recommendations based on your latest analysis</p>
           </div>
 
-          {/* 다시 분석하기 */}
-          <Link href="/upload">
-            <Button
-              variant="outline"
-              className="w-full py-6 rounded-full border-[#C4B5FD] text-[#8B7DCF] hover:bg-[#C4B5FD]/10 font-medium text-base"
-            >
-              <Camera className="w-5 h-5 mr-2" />
-              새로 분석하기
-              <ChevronRight className="w-4 h-4 ml-auto" />
-            </Button>
-          </Link>
+          {features.map((feature) => (
+            <Link key={feature.href} href={feature.href}>
+              <Card className={`p-5 rounded-2xl border-border/50 shadow-sm bg-linear-to-br ${feature.bg} hover:shadow-md transition-shadow`}>
+                <div className="flex items-center gap-4">
+                  <div
+                    className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0"
+                    style={{ backgroundColor: `${feature.color}20` }}
+                  >
+                    <feature.icon className="w-7 h-7" style={{ color: feature.color }} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="font-semibold text-foreground mb-1">{feature.title}</h2>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      {feature.description}
+                    </p>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0" />
+                </div>
+              </Card>
+            </Link>
+          ))}
         </main>
 
         <BottomNav activeTab="style" />

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -57,7 +57,7 @@ export default function UploadPage() {
 
   const handleFile = useCallback((file: File) => {
   if (file && file.type.startsWith("image/")) {
-    setSelectedFile(file)  // 추가
+    setSelectedFile(file)
     const reader = new FileReader()
     reader.onload = (e) => setImage(e.target?.result as string)
     reader.readAsDataURL(file)
@@ -104,7 +104,7 @@ export default function UploadPage() {
 
       const file = selectedFile
     
-      // Step 2 - Skin analysis (실제 API 호출)
+      // Step 2 - Skin analysis (actual API call)
       setCurrentStep(1)
       setProgress(66)
     
@@ -115,7 +115,7 @@ export default function UploadPage() {
       setProgress(100)
 
       setTimeout(() => {
-        // 결과 페이지로 이동하면서 데이터 전달
+        // Navigate to result page with data
         const params = new URLSearchParams()
         params.set('data', JSON.stringify(result))
         window.location.href = `/result?${params.toString()}`

--- a/frontend/src/components/bottom-nav.tsx
+++ b/frontend/src/components/bottom-nav.tsx
@@ -63,7 +63,7 @@ export function BottomNav() {
           badge="Beta"
         />
 
-        {/* Profile / login — href 분기 */}
+        {/* Profile / login — conditional href */}
         <Link
           href={profileHref}
           className="flex flex-col items-center gap-1 text-muted-foreground transition-colors"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,20 @@ export async function analyzeImage(file: File): Promise<AnalyzeResponse> {
     return res.json()
 }
 
+export async function getMakeupRecommendation(skin_type: string, lighting_env: string) {
+    const res = await fetch(`${API_BASE_URL}/recommend/makeup`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skin_type, lighting_env }),
+    })
+    if (!res.ok) {
+        const error = await res.json()
+        throw new Error(error.detail || 'Failed to get makeup recommendation')
+    }
+    return res.json()
+}
+
 export async function getHairstyleRecommendation(landmarks: [number, number][]) {
     const res = await fetch(`${API_BASE_URL}/recommend/hairstyle`, {
         method: 'POST',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -7,9 +7,9 @@ export const SKIN_STATUS_THRESHOLDS = {
 }
 
 export const SKIN_LABELS = {
-  redness:    { good: '진정됨', caution: '약간 붉음', bad: '붉음' },
-  tone:       { good: '균일', caution: '약간 불균일', bad: '불균일' },
-  brightness: { good: '밝음', caution: '보통', bad: '칙칙함' },
-  trouble:    { good: '깨끗', caution: '약간 있음', bad: '트러블' },
-  moisture:   { good: '촉촉', caution: '보통', bad: '건조' },
+  redness:    { good: 'Calm', caution: 'Slightly red', bad: 'Red' },
+  tone:       { good: 'Even', caution: 'Slightly uneven', bad: 'Uneven' },
+  brightness: { good: 'Bright', caution: 'Moderate', bad: 'Dull' },
+  trouble:    { good: 'Clear', caution: 'Slight trouble', bad: 'Trouble' },
+  moisture:   { good: 'Hydrated', caution: 'Moderate', bad: 'Dry' },
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,25 +1,25 @@
-// 항목별 상태 타입
+// Per-metric status type
 export type SkinStatus = 'good' | 'caution' | 'bad'
 
-// 항목별 분석 결과
+// Per-metric analysis result
 export interface SkinMetric {
-  score: number        // 0~100 원본 점수
-  chart_score: number  // 레이더 차트용 정규화 점수 (높을수록 좋음)
+  score: number        // 0~100 raw score
+  chart_score: number  // normalized score for radar chart (higher = better)
   status: SkinStatus   // good / caution / bad
-  label: string        // 한국어 라벨 (예: "약간 붉음")
+  label: string        // English label (e.g. "Slightly red")
 }
 
-// 피부 분석 결과
+// Skin analysis scores
 export interface SkinScores {
   redness: SkinMetric
   tone: SkinMetric
   brightness: SkinMetric
   trouble: SkinMetric
   moisture: SkinMetric
-  overall: number      // 종합 점수
+  overall: number      // overall score
 }
 
-// 추천 제품
+// Recommended product
 export interface Product {
   id: string
   name: string
@@ -31,17 +31,17 @@ export interface Product {
   image_url?: string
 }
 
-// 분석 API 응답
+// Analyze API response
 export interface AnalyzeResponse {
   skin_scores: SkinScores
   skin_type: string
   products: Product[]
   analyzed_at: string
   landmarks: [number, number][]
-  image_size: { width: number, height: number } 
+  image_size: { width: number, height: number }
 }
 
-// 히스토리 항목
+// History item
 export interface HistoryItem {
   id: string
   skin_type: string
@@ -53,7 +53,7 @@ export interface HistoryItem {
   image_size: { width: number; height: number }
 }
 
-// 에러 응답
+// Error response
 export interface ApiError {
   detail: string
 }


### PR DESCRIPTION
## Summary
- Add `POST /recommend/makeup` — returns color palette by lighting × skin type
- Add `data/makeup_palettes.json` — 3 lighting × 4 skin type palette + tips
- Integrate Gemini 2.0 Flash for palette description (fallback to string on quota exceeded)
- Migrate `google-generativeai` → `google-genai` SDK
- Add `/style/makeup` page — lighting toggle, color swatches, product cards
- Refactor `/style` page into menu (hairstyle + makeup)
- Move hairstyle logic to `/style/hairstyle`
- Add makeup shortcut card on result page
- Translate all Korean strings to English (UI, backend labels, JSON data)
- Add `restart: unless-stopped` to frontend Docker service

## Test plan
- [ ] `POST /recommend/makeup` returns palette + tip
- [ ] Lighting toggle updates palette on `/style/makeup`
- [ ] Gemini quota exceeded → fallback string returned (not error)
- [ ] No Korean text visible in UI
